### PR TITLE
Correction du code d'authentification dans l'email

### DIFF
--- a/lib/habilitations/strategies/email/pin-code-template.js
+++ b/lib/habilitations/strategies/email/pin-code-template.js
@@ -55,7 +55,7 @@ const bodyTemplate = template(`
 
   <div class="container">
     <h3>Voici votre code :</h5>
-    <div class="code"><%= code %></div>
+    <div class="code"><%= pinCode %></div>
   </div>
 
   <br />
@@ -73,11 +73,11 @@ const bodyTemplate = template(`
 `)
 
 function formatEmail(data) {
-  const {code, nomCommune} = data
+  const {pinCode, nomCommune} = data
 
   return {
     subject: 'Demande de code d’identification',
-    html: bodyTemplate({code, nomCommune})
+    html: bodyTemplate({pinCode, nomCommune})
   }
 }
 


### PR DESCRIPTION
### Contexte
Le code d'authentification n'arrive jamais dans le template de l'email envoyé aux communes à cause d'une erreur de nommage.
