### PR TITLE
Corrections du processus d'habilitation

### DIFF
--- a/lib/habilitations/model.js
+++ b/lib/habilitations/model.js
@@ -1,6 +1,35 @@
+const got = require('got')
 const mongo = require('../util/mongo')
+const {deburr} = require('lodash')
 const createError = require('http-errors')
-const {getCommuneEmail} = require('./strategies/email')
+
+async function getCommuneEmail(codeCommune) {
+  try {
+    const response = await got(`${API_ETABLISSEMENTS_PUBLICS}/communes/${codeCommune}/mairie`, {responseType: 'json'})
+    const mairie = response.body.features
+      .find(m => !normalize(m.properties.nom).includes('deleguee'))
+
+    const {email} = mairie.properties
+    if (validateEmail(email)) {
+      return email
+    }
+
+    throw new Error(`L’adresse email " ${email} " ne peut pas être utilisée`)
+  } catch (error) {
+    console.log(`Une erreur s’est produite lors de la récupération de l’adresse email de la mairie (Code commune: ${codeCommune}).`, error)
+  }
+}
+
+function normalize(str) {
+  return deburr(str).toLowerCase()
+}
+
+const API_ETABLISSEMENTS_PUBLICS = process.env.API_ETABLISSEMENTS_PUBLICS || 'https://etablissements-publics.api.gouv.fr/v3'
+
+function validateEmail(email) {
+  const re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[(?:\d{1,3}\.){3}\d{1,3}])|(([a-zA-Z\-\d]+\.)+[a-zA-Z]{2,}))$/
+  return re.test(String(email).toLowerCase())
+}
 
 async function createHabilitation({codeCommune, client}) {
   const now = new Date()

--- a/lib/habilitations/routes.js
+++ b/lib/habilitations/routes.js
@@ -99,7 +99,7 @@ async function habilitationsRoutes(params = {}) {
     const {validated, error} = await pinCodeValidation(req.body.code, req.habilitation)
 
     if (!validated) {
-      res.send({validated, error})
+      return res.send({validated, error})
     }
 
     const habilitation = await validateHabilitation(req.habilitation)

--- a/lib/habilitations/strategies/email.js
+++ b/lib/habilitations/strategies/email.js
@@ -1,35 +1,5 @@
-const got = require('got')
 const randomNumber = require('random-number-csprng')
-const {deburr} = require('lodash')
 const Habilitation = require('../model')
-
-function normalize(str) {
-  return deburr(str).toLowerCase()
-}
-
-const API_ETABLISSEMENTS_PUBLICS = process.env.API_ETABLISSEMENTS_PUBLICS || 'https://etablissements-publics.api.gouv.fr/v3'
-
-function validateEmail(email) {
-  const re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[(?:\d{1,3}\.){3}\d{1,3}])|(([a-zA-Z\-\d]+\.)+[a-zA-Z]{2,}))$/
-  return re.test(String(email).toLowerCase())
-}
-
-async function getCommuneEmail(codeCommune) {
-  try {
-    const response = await got(`${API_ETABLISSEMENTS_PUBLICS}/communes/${codeCommune}/mairie`, {responseType: 'json'})
-    const mairie = response.body.features
-      .find(m => !normalize(m.properties.nom).includes('deleguee'))
-
-    const {email} = mairie.properties
-    if (validateEmail(email)) {
-      return email
-    }
-
-    throw new Error(`L’adresse email " ${email} " ne peut pas être utilisée`)
-  } catch (error) {
-    console.log(`Une erreur s’est produite lors de la récupération de l’adresse email de la mairie (Code commune: ${codeCommune}).`, error)
-  }
-}
 
 async function generatePinCode() {
   return (await randomNumber(0, 999999)).toString().padStart(6, '0')
@@ -69,4 +39,4 @@ async function pinCodeValidation(code, habilitation) {
   return {validated: true}
 }
 
-module.exports = {getCommuneEmail, pinCodeValidation, generatePinCode, hasBeenSentRecently, getExpirationDate}
+module.exports = {pinCodeValidation, generatePinCode, hasBeenSentRecently, getExpirationDate}


### PR DESCRIPTION
### Dépendance circulaire entre `/lib/habilitations/strategies/email.js` et `/lib/habilitations/model.js`
- méthode `getCommuneEmail` de `email.js`, utilisé dans `model.js`
- méthodes `decreasesRemainingAttempts` et `rejectHabilitation` de `model.js`, utilisé dans `email.js`

La dépendance circulaire est résolue en déplaçant la méthode `getCommuneEmail` et le code la concernant directement dans `model.js`, sans endroit où cette méthode est utilisée aujourd'hui.

### Double appel à `res.send()`
Dans le cas où `!validated` alors la méthode `send` était appelé deux fois. Un `return` a été ajouté afin de stopper l'exécution du code.