### PR TITLE
Corrige le terme "authentication"

### DIFF
--- a/lib/habilitations/__tests__/routes.js
+++ b/lib/habilitations/__tests__/routes.js
@@ -64,7 +64,7 @@ test('basic habilitation', async t => {
   t.is(res1.body.status, 'pending')
 
   await request(server)
-    .post(`/habilitations/${habilitationId}/authentification/email/send-pin-code`)
+    .post(`/habilitations/${habilitationId}/authentication/email/send-pin-code`)
     .set('Authorization', 'Token foobar')
     .expect(200)
 
@@ -76,7 +76,7 @@ test('basic habilitation', async t => {
   t.is(habilitation.strategy.remainingAttempts, 10)
 
   const res2 = await request(server)
-    .post(`/habilitations/${habilitationId}/authentification/email/validate-pin-code`)
+    .post(`/habilitations/${habilitationId}/authentication/email/validate-pin-code`)
     .set('Authorization', 'Token foobar')
     .send({code: habilitation.strategy.pinCode})
     .expect(200)

--- a/lib/habilitations/routes.js
+++ b/lib/habilitations/routes.js
@@ -44,7 +44,7 @@ async function habilitationsRoutes(params = {}) {
     res.send(req.habilitation)
   }))
 
-  app.post('/habilitations/:habilitationId/authentification/email/send-pin-code', authClient, w(async (req, res) => {
+  app.post('/habilitations/:habilitationId/authentication/email/send-pin-code', authClient, w(async (req, res) => {
     const {status, codeCommune, emailCommune, strategy} = req.habilitation
 
     if (status === 'accepted') {
@@ -81,7 +81,7 @@ async function habilitationsRoutes(params = {}) {
     res.sendStatus(200)
   }))
 
-  app.post('/habilitations/:habilitationId/authentification/email/validate-pin-code', authClient, w(async (req, res) => {
+  app.post('/habilitations/:habilitationId/authentication/email/validate-pin-code', authClient, w(async (req, res) => {
     if (!req.body.code) {
       throw createError(400, '`code` est un champ obligatoire')
     }


### PR DESCRIPTION
Corrige le terme français "authentification" en français par "authentication" dans les routes.