### PR TITLE
Ajout du nombre de tentative restante lors de la validation du code

### DIFF
--- a/lib/habilitations/strategies/email/index.js
+++ b/lib/habilitations/strategies/email/index.js
@@ -22,19 +22,33 @@ function getExpirationDate(startDate) {
 async function pinCodeValidation(code, habilitation) {
   if (code !== habilitation.strategy.pinCode) {
     const {strategy} = await decreasesRemainingAttempts(habilitation._id)
+    const {remainingAttempts} = strategy
 
-    if (strategy.remainingAttempts === 0) {
+    if (remainingAttempts === 0) {
       await Habilitation.rejectHabilitation(habilitation._id)
-      return {validated: false, error: 'Code non valide, demande d’habilitation rejetée'}
+
+      return {
+        validated: false,
+        error: 'Code non valide, demande d’habilitation rejetée'
+      }
     }
 
-    const plural = strategy.remainingAttempts > 1 ? 's' : ''
-    return {validated: false, error: `Code non valide, ${strategy.remainingAttempts} tentative${plural} retestante${plural}`}
+    const plural = remainingAttempts > 1 ? 's' : ''
+
+    return {
+      validated: false,
+      error: `Code non valide, ${remainingAttempts} tentative${plural} retestante${plural}`,
+      remainingAttempts
+    }
   }
 
   const now = new Date()
+
   if (now > habilitation.strategy.pinCodeExpiration) {
-    return {validated: false, error: 'Code expiré'}
+    return {
+      validated: false,
+      error: 'Code expiré'
+    }
   }
 
   return {validated: true}

--- a/lib/habilitations/strategies/email/index.js
+++ b/lib/habilitations/strategies/email/index.js
@@ -29,7 +29,7 @@ async function pinCodeValidation(code, habilitation) {
 
       return {
         validated: false,
-        error: 'Code non valide, demande d’habilitation rejetée'
+        error: 'Code non valide. Demande rejetée.'
       }
     }
 
@@ -37,7 +37,7 @@ async function pinCodeValidation(code, habilitation) {
 
     return {
       validated: false,
-      error: `Code non valide, ${remainingAttempts} tentative${plural} retestante${plural}`,
+      error: `Code non valide, ${remainingAttempts} tentative${plural} restante${plural}`,
       remainingAttempts
     }
   }


### PR DESCRIPTION
## Contexte
Actuellement la propriété `remainingAttempts` n'est pas renvoyée par la méthode `pinCodeValidation` hors cette information peut être utile pour suivre plus facilement le nombre de tentative restante.

## Description
Cette PR ajoute le champ `remainingAttempts` dans le réponse de la méthode `pinCodeValidation` dans les cas où le code n'est pas valide et que `remainingAttempts` est supérieur à 0.