### PR TITLE
Envoi le champ `remainingAttempts` 

### DIFF
--- a/lib/habilitations/routes.js
+++ b/lib/habilitations/routes.js
@@ -116,10 +116,10 @@ async function habilitationsRoutes(params = {}) {
       throw createError(412, 'Cette habilitation est rejetée')
     }
 
-    const {validated, error} = await pinCodeValidation(req.body.code, req.habilitation)
+    const {validated, error, remainingAttempts} = await pinCodeValidation(req.body.code, req.habilitation)
 
     if (!validated) {
-      return res.send({validated, error})
+      return res.send({validated, error, remainingAttempts})
     }
 
     await acceptHabilitation(req.habilitation._id)


### PR DESCRIPTION
Oubli lors de #14, le champ `remainingAttempts ` n'est pas envoyé dans la réponse de l'API…