### PR TITLE
Mise à jour de @ban-team/validateur-bal

### DIFF
--- a/lib/revisions/validate-bal.js
+++ b/lib/revisions/validate-bal.js
@@ -1,7 +1,7 @@
 const {intersection, union, difference} = require('lodash')
-const {validate} = require('@etalab/bal')
-const {errors: baseErrors, warnings: baseWarnings, infos: baseInfos} = require('@etalab/bal/lib/schema/profiles/1.3-etalab')
-const {version: validatorVersion} = require('@etalab/bal/package.json')
+const {validate} = require('@ban-team/validateur-bal')
+const {errors: baseErrors, warnings: baseWarnings, infos: baseInfos} = require('@ban-team/validateur-bal/lib/schema/profiles/1.3-etalab')
+const {version: validatorVersion} = require('@ban-team/validateur-bal/package.json')
 
 const createError = require('http-errors')
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "@ban-team/validateur-bal": "^2.8.0",
-    "@etalab/bal": "^2.6.0",
     "@etalab/decoupage-administratif": "^2.0.0",
     "@slack/web-api": "^6.7.0",
     "bytes": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "habilitations:build-rne": "node lib/habilitations/build-rne"
   },
   "dependencies": {
+    "@ban-team/validateur-bal": "^2.8.0",
     "@etalab/bal": "^2.6.0",
     "@etalab/decoupage-administratif": "^2.0.0",
     "@slack/web-api": "^6.7.0",

--- a/scripts/revalidate-revisions.js
+++ b/scripts/revalidate-revisions.js
@@ -2,7 +2,7 @@
 /* eslint no-await-in-loop: off */
 require('dotenv').config()
 
-const validatorVersion = require('@etalab/bal/package.json').version
+const validatorVersion = require('@ban-team/validateur-bal/package.json').version
 const mongo = require('../lib/util/mongo')
 const {fetchRevision, getFiles, getFileData} = require('../lib/revisions/model')
 const {applyValidateBAL} = require('../lib/revisions/validate-bal')

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,6 +28,23 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@ban-team/validateur-bal@^2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@ban-team/validateur-bal/-/validateur-bal-2.8.0.tgz#09c8b5854ab6b96d8779287bc7430150dbaeccf7"
+  integrity sha512-LusrzcHN9+0mjX0XIUjTjsrjiOD7158XPOucVtLxYEJ6I83ySdTg4MyW4QkJOxrsruf/ylEcdc+ZN2u0N5y3AQ==
+  dependencies:
+    "@etalab/project-legal" "^0.6.0"
+    blob-to-buffer "^1.2.9"
+    bluebird "^3.7.2"
+    chalk "^4.1.2"
+    chardet "^1.4.0"
+    date-fns "^2.28.0"
+    file-type "^12.4.2"
+    iconv-lite "^0.6.3"
+    lodash "^4.17.21"
+    papaparse "^5.3.2"
+    yargs "^17.5.0"
+
 "@eslint/eslintrc@^1.0.5", "@eslint/eslintrc@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.1.0.tgz#583d12dbec5d4f22f333f9669f7d0b7c7815b4d3"
@@ -63,6 +80,13 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@etalab/decoupage-administratif/-/decoupage-administratif-2.0.0.tgz#24ee640070c47e3c62883873c35450197fa5f78c"
   integrity sha512-X+pQDnm0Sk8T5KPhT5kU9cLyMKc+LagK8ObYxyzVDoQapjLNZl9/KY2VFr42aw4LEiTnUfqCgNZc9lhHfi6shQ==
+
+"@etalab/project-legal@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@etalab/project-legal/-/project-legal-0.6.0.tgz#9932f023b85e91578fb3249e885677cb18ec072d"
+  integrity sha512-GgxpN38fpYRM+yuTw6HyhWYUnZo9Ux/sy9OZ27nblKhf6tW3PvO2Ts2OrYw+D9IzQWonVOl9gyHOsPjX91YhXg==
+  dependencies:
+    proj4 "^2.8.0"
 
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.5"
@@ -2966,6 +2990,11 @@ methods@^1.1.2, methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
+mgrs@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mgrs/-/mgrs-1.0.0.tgz#fb91588e78c90025672395cb40b25f7cd6ad1829"
+  integrity sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA==
+
 micro-spelling-correcter@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/micro-spelling-correcter/-/micro-spelling-correcter-1.1.1.tgz#805a06a26ccfcad8f3e5c6a1ac5ff29d4530166e"
@@ -3639,6 +3668,14 @@ pretty-ms@^7.0.1:
   integrity sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==
   dependencies:
     parse-ms "^2.1.0"
+
+proj4@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/proj4/-/proj4-2.8.0.tgz#b2cb8f3ccd56d4dcc7c3e46155cd02caa804b170"
+  integrity sha512-baC+YcD4xsSqJ+CpCZljj2gcQDhlKb+J+Zjv/2KSBwWNjk4M0pafgQsE+mWurd84tflMIsP+7j7mtIpFDHzQfQ==
+  dependencies:
+    mgrs "1.0.0"
+    wkt-parser "^1.3.1"
 
 proto-props@^2.0.0:
   version "2.0.0"
@@ -4521,6 +4558,11 @@ which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+wkt-parser@^1.3.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/wkt-parser/-/wkt-parser-1.3.2.tgz#deeff04a21edc5b170a60da418e9ed1d1ab0e219"
+  integrity sha512-A26BOOo7sHAagyxG7iuRhnKMO7Q3mEOiOT4oGUmohtN/Li5wameeU4S6f8vWw6NADTVKljBs8bzA8JPQgSEMVQ==
 
 word-wrap@^1.2.3:
   version "1.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,22 +60,6 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@etalab/bal@^2.6.0":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@etalab/bal/-/bal-2.6.0.tgz#8146a2d9c16e2825e9d5e8d1a29abbe1a3ce7644"
-  integrity sha512-LAiXIT0gKmjlr4rNPuzKjqxC2OezfG2PdatGKph0SyslyyawGpQNalSnUEPYCd3aZGpwqvEZJstbx9nQkZxv+Q==
-  dependencies:
-    blob-to-buffer "^1.2.9"
-    bluebird "^3.7.2"
-    chalk "^4.1.2"
-    chardet "^1.4.0"
-    date-fns "^2.28.0"
-    file-type "^12.4.2"
-    iconv-lite "^0.6.3"
-    lodash "^4.17.21"
-    papaparse "^5.3.2"
-    yargs "^17.5.0"
-
 "@etalab/decoupage-administratif@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@etalab/decoupage-administratif/-/decoupage-administratif-2.0.0.tgz#24ee640070c47e3c62883873c35450197fa5f78c"


### PR DESCRIPTION
Mise à jour de @ban-team/validateur-bal de la version `2.6.0` à `2.8.0`.

Voir les détails de cette version 
https://github.com/BaseAdresseNationale/validateur-bal/releases/tag/v2.8.0

## Évolutions
`@etalab/bal` est remplacé par `@ban-team/validateur-bal` (nouveau nom de la dépendance).