### PR TITLE
PR modification pour vérifier la structure et la présence de l'id issue 26

### DIFF
--- a/lib/revisions/validate-bal.js
+++ b/lib/revisions/validate-bal.js
@@ -9,6 +9,8 @@ const strictModeAdditionalErrors = [
   'cle_interop.valeur_manquante',
   'cle_interop.numero_prefixe_manquant',
   'cle_interop.casse_invalide',
+  'uid.valeur_manquante',
+  'uid.structure_invalide',
   'numero.contient_prefixe',
   'suffixe.espaces_debut_fin',
   'commune_insee.valeur_manquante',
@@ -59,6 +61,7 @@ async function applyValidateBAL(file, codeCommune, options = {}) {
   }
 
   const errors = relaxMode ? baseErrors : union(baseErrors, strictModeAdditionalErrors)
+
   const warnings = relaxMode ? baseWarnings : difference(baseWarnings, strictModeAdditionalErrors)
   const infos = relaxMode ? baseInfos : difference(baseInfos, strictModeAdditionalErrors)
 

--- a/lib/revisions/validate-bal.js
+++ b/lib/revisions/validate-bal.js
@@ -9,8 +9,8 @@ const strictModeAdditionalErrors = [
   'cle_interop.valeur_manquante',
   'cle_interop.numero_prefixe_manquant',
   'cle_interop.casse_invalide',
-  'uid.valeur_manquante',
-  'uid.structure_invalide',
+  'uid_adresse.valeur_manquante',
+  'uid_adresse.structure_invalide',
   'numero.contient_prefixe',
   'suffixe.espaces_debut_fin',
   'commune_insee.valeur_manquante',
@@ -61,7 +61,6 @@ async function applyValidateBAL(file, codeCommune, options = {}) {
   }
 
   const errors = relaxMode ? baseErrors : union(baseErrors, strictModeAdditionalErrors)
-
   const warnings = relaxMode ? baseWarnings : difference(baseWarnings, strictModeAdditionalErrors)
   const infos = relaxMode ? baseInfos : difference(baseInfos, strictModeAdditionalErrors)
 


### PR DESCRIPTION
PR a tester avec la branche du validateur https://github.com/BaseAdresseNationale/validateur-bal/tree/mmortier/issue53

Tester les cas suivants :

- uuid vides (doit renvoyer une erreur valeur vide)
- uuid remplis mais à mauvaise structure (doit renvoyer une erreur structure invalide)
- uuid remplis et structure uuidv4 (doit renvoyer valid)

Ne pas merger dans master mais dans prototype

exemple de fichier à tester : ici avec des uuid correctes.

cle_interop;uid_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;certification_commune;commune_insee;commune_nom;position;long;lat;x;y;cad_parcelles;source;date_der_maj
59656_xxxx_00009;a50312be-854f-4b65-ba0a-e0049b0b576a;Allee du Coteau (9-13);;9;;0;59656;Wervicq-Sud;entrée;3.051014;50.766559;703605.7;7074443.64;591656000A2919;commune;2022-09-01
59656_xxxx_00011;3cdf0890-23ad-4ea9-9a6a-6b18f0440da6;Allee du Coteau (9-13);;11;;0;59656;Wervicq-Sud;entrée;3.05073;50.766494;703585.64;7074436.33;591656000A2920;commune;2022-09-01
59656_xxxx_00001;cf10a5d9-0b3c-4f45-9a6f-1df9cdb64a58;Allee Despaquerettes;;1;;0;59656;Wervicq-Sud;entrée;3.055837;50.762752;703946.95;7074019.53;591656000A3861;commune;2022-09-01 

fix #27 