### PR TITLE
Permet de supprimer les fichiers d'une révision

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -15,3 +15,4 @@ FC_FS_ID=
 FC_FS_SECRET=
 FC_FS_CALLBACK=https://plateforme.adresse.data.gouv.fr/api-depot/habilitations/franceconnect/callback
 SESSION_SECRET=foobar
+ADMIN_TOKEN=

--- a/lib/revisions/__tests__/integration.js
+++ b/lib/revisions/__tests__/integration.js
@@ -1,3 +1,7 @@
+require('dotenv').config()
+
+process.env.ADMIN_TOKEN = 'foobarAdmin'
+
 const {join} = require('path')
 const {readFile} = require('fs').promises
 const test = require('ava')
@@ -47,11 +51,31 @@ test('authentication / success', async t => {
   t.deepEqual(res.body, {name: 'ACME'})
 })
 
+test('admin authentication / success', async t => {
+  const server = await getApp()
+  await request(server)
+    .get('/admin')
+    .set('Authorization', 'Token foobarAdmin')
+    .expect(200)
+
+  t.pass()
+})
+
 test('authentication / fail', async t => {
   const server = await getApp({clients: [fakeClient]})
   await request(server)
     .get('/me')
     .set('Authorization', 'Token ohnooo')
+    .expect(401)
+
+  t.pass()
+})
+
+test('admin authentication / fail', async t => {
+  const server = await getApp()
+  await request(server)
+    .get('/admin')
+    .set('Authorization', 'Token foobar')
     .expect(401)
 
   t.pass()
@@ -126,4 +150,64 @@ test.serial('basic revision', async t => {
 
   t.is(res7.body.length, 1)
   t.is(res7.body[0]._id, revisionId)
+})
+
+test.serial('remove files from revision', async t => {
+  const server = await getApp({clients: [fakeClient]})
+
+  const res1 = await request(server)
+    .post('/communes/31591/revisions')
+    .set('Authorization', 'Token foobar')
+    .set('Content-Type', 'application/json')
+    .send(JSON.stringify({context: {organisation: 'ACME'}}))
+    .expect(201)
+
+  t.is(res1.body.context.organisation, 'ACME')
+  t.is(res1.body.status, 'pending')
+  t.is(res1.body.ready, false)
+  t.is(res1.body.codeCommune, '31591')
+
+  const revisionId = res1.body._id
+
+  const balFile = await readFile(join(__dirname, 'fixtures', 'bal-valid.csv'))
+
+  const res2 = await request(server)
+    .put(`/revisions/${revisionId}/files/bal`)
+    .set('Authorization', 'Token foobar')
+    .set('Content-Type', 'text/csv')
+    .set('Content-Disposition', 'attachment; filename=31591.csv')
+    .send(balFile)
+    .expect(200)
+
+  t.is(res2.body.size, 793)
+  t.is(res2.body.name, '31591.csv')
+  t.is(res2.body.type, 'bal')
+  t.is(res2.body.hash, '8e67eef2db54dc96c3165060e4dc3b5239fcf82f7e61e3d72e72dfdf9ae2b16c')
+  t.is(res2.body.revisionId, revisionId)
+
+  const res3 = await request(server)
+    .get(`/revisions/${revisionId}`)
+    .set('Authorization', 'Token foobar')
+    .expect(200)
+
+  t.is(res3.body._id, revisionId)
+  t.is(res3.body.files[0].size, 793)
+  t.is(res3.body.files[0].name, '31591.csv')
+  t.is(res3.body.files[0].type, 'bal')
+  t.is(res3.body.files[0].hash, '8e67eef2db54dc96c3165060e4dc3b5239fcf82f7e61e3d72e72dfdf9ae2b16c')
+
+  const res4 = await request(server)
+    .delete(`/revisions/${revisionId}`)
+    .set('Authorization', 'Token foobarAdmin')
+    .expect(200)
+
+  t.is(res4.body._id, revisionId)
+  t.is(res4.body.files, undefined)
+
+  const res5 = await request(server)
+    .get(`/revisions/${revisionId}`)
+    .set('Authorization', 'Token foobar')
+    .expect(200)
+
+  t.is(res5.body.files.length, 0)
 })

--- a/lib/revisions/__tests__/integration.js
+++ b/lib/revisions/__tests__/integration.js
@@ -155,70 +155,145 @@ test.serial('basic revision', async t => {
 test.serial('remove revision and files', async t => {
   const server = await getApp({clients: [fakeClient]})
 
-  const res1 = await request(server)
+  const revisionA = await request(server)
     .post('/communes/31591/revisions')
     .set('Authorization', 'Token foobar')
     .set('Content-Type', 'application/json')
     .send(JSON.stringify({context: {organisation: 'ACME'}}))
     .expect(201)
 
-  t.is(res1.body.context.organisation, 'ACME')
-  t.is(res1.body.status, 'pending')
-  t.is(res1.body.ready, false)
-  t.is(res1.body.codeCommune, '31591')
+  const revisionB = await request(server)
+    .post('/communes/31591/revisions')
+    .set('Authorization', 'Token foobar')
+    .set('Content-Type', 'application/json')
+    .send(JSON.stringify({context: {organisation: 'ACME'}}))
+    .expect(201)
 
-  const revisionId = res1.body._id
+  const revisionC = await request(server)
+    .post('/communes/31591/revisions')
+    .set('Authorization', 'Token foobar')
+    .set('Content-Type', 'application/json')
+    .send(JSON.stringify({context: {organisation: 'ACME'}}))
+    .expect(201)
+
+  t.is(revisionC.body.context.organisation, 'ACME')
+  t.is(revisionC.body.status, 'pending')
+  t.is(revisionC.body.ready, false)
+  t.is(revisionC.body.codeCommune, '31591')
+
+  const revisionIdA = revisionA.body._id
+  const revisionIdB = revisionB.body._id
+  const revisionIdC = revisionC.body._id
 
   const balFile = await readFile(join(__dirname, 'fixtures', 'bal-valid.csv'))
 
-  const res2 = await request(server)
-    .put(`/revisions/${revisionId}/files/bal`)
+  await request(server)
+    .put(`/revisions/${revisionIdA}/files/bal`)
     .set('Authorization', 'Token foobar')
     .set('Content-Type', 'text/csv')
     .set('Content-Disposition', 'attachment; filename=31591.csv')
     .send(balFile)
     .expect(200)
 
-  t.is(res2.body.size, 793)
-  t.is(res2.body.name, '31591.csv')
-  t.is(res2.body.type, 'bal')
-  t.is(res2.body.hash, '8e67eef2db54dc96c3165060e4dc3b5239fcf82f7e61e3d72e72dfdf9ae2b16c')
-  t.is(res2.body.revisionId, revisionId)
+  await request(server)
+    .put(`/revisions/${revisionIdB}/files/bal`)
+    .set('Authorization', 'Token foobar')
+    .set('Content-Type', 'text/csv')
+    .set('Content-Disposition', 'attachment; filename=31591.csv')
+    .send(balFile)
+    .expect(200)
 
-  const res3 = await request(server)
-    .get(`/revisions/${revisionId}`)
+  const revisionFilesC = await request(server)
+    .put(`/revisions/${revisionIdC}/files/bal`)
+    .set('Authorization', 'Token foobar')
+    .set('Content-Type', 'text/csv')
+    .set('Content-Disposition', 'attachment; filename=31591.csv')
+    .send(balFile)
+    .expect(200)
+
+  t.is(revisionFilesC.body.size, 793)
+  t.is(revisionFilesC.body.name, '31591.csv')
+  t.is(revisionFilesC.body.type, 'bal')
+  t.is(revisionFilesC.body.hash, '8e67eef2db54dc96c3165060e4dc3b5239fcf82f7e61e3d72e72dfdf9ae2b16c')
+  t.is(revisionFilesC.body.revisionId, revisionIdC)
+
+  const revisionResC = await request(server)
+    .get(`/revisions/${revisionIdC}`)
     .set('Authorization', 'Token foobar')
     .expect(200)
 
-  t.is(res3.body._id, revisionId)
-  t.is(res3.body.files[0].size, 793)
-  t.is(res3.body.files[0].name, '31591.csv')
-  t.is(res3.body.files[0].type, 'bal')
-  t.is(res3.body.files[0].hash, '8e67eef2db54dc96c3165060e4dc3b5239fcf82f7e61e3d72e72dfdf9ae2b16c')
-
-  const res4 = await request(server)
-    .post(`/revisions/${revisionId}/compute`)
-    .set('Authorization', 'Token foobar')
-    .expect(200)
-
-  t.is(res4.body.validation.valid, true)
-  t.is(res4.body.ready, true)
-
-  const res5 = await request(server)
-    .post(`/revisions/${revisionId}/publish`)
-    .set('Authorization', 'Token foobar')
-    .expect(200)
-
-  t.is(res5.body.status, 'published')
-  t.is(res5.body.current, true)
+  t.is(revisionResC.body._id, revisionIdC)
+  t.is(revisionResC.body.files[0].size, 793)
+  t.is(revisionResC.body.files[0].name, '31591.csv')
+  t.is(revisionResC.body.files[0].type, 'bal')
+  t.is(revisionResC.body.files[0].hash, '8e67eef2db54dc96c3165060e4dc3b5239fcf82f7e61e3d72e72dfdf9ae2b16c')
 
   await request(server)
-    .delete(`/revisions/${revisionId}`)
+    .post(`/revisions/${revisionIdB}/compute`)
+    .set('Authorization', 'Token foobar')
+    .expect(200)
+
+  await request(server)
+    .post(`/revisions/${revisionIdB}/publish`)
+    .set('Authorization', 'Token foobar')
+    .expect(200)
+
+  const revisionComputeResC = await request(server)
+    .post(`/revisions/${revisionIdC}/compute`)
+    .set('Authorization', 'Token foobar')
+    .expect(200)
+
+  t.is(revisionComputeResC.body.validation.valid, true)
+  t.is(revisionComputeResC.body.ready, true)
+
+  const revisionPublishResC = await request(server)
+    .post(`/revisions/${revisionIdC}/publish`)
+    .set('Authorization', 'Token foobar')
+    .expect(200)
+
+  t.is(revisionPublishResC.body.status, 'published')
+  t.is(revisionPublishResC.body.current, true)
+
+  await request(server)
+    .get(`/revisions/${revisionIdB}`)
+    .set('Authorization', 'Token foobar')
+    .expect(200)
+
+  const publishedRevisionC = await request(server)
+    .get(`/revisions/${revisionIdC}`)
+    .set('Authorization', 'Token foobar')
+    .expect(200)
+
+  t.is(publishedRevisionC.body.status, 'published')
+  t.is(publishedRevisionC.body.current, true)
+
+  await request(server)
+    .post(`/revisions/${revisionIdA}/compute`)
+    .set('Authorization', 'Token foobar')
+    .expect(200)
+
+  await request(server)
+    .delete(`/revisions/${revisionIdC}`)
     .set('Authorization', 'Token foobarAdmin')
     .expect(204)
 
   await request(server)
-    .get(`/revisions/${revisionId}`)
+    .get(`/revisions/${revisionIdC}`)
+    .set('Authorization', 'Token foobar')
+    .expect(404)
+
+  const currentRevision = await request(server)
+    .get(`/revisions/${revisionIdB}`)
+    .set('Authorization', 'Token foobar')
+    .expect(200)
+
+  t.is(currentRevision.body._id, revisionIdB)
+  t.is(currentRevision.body.codeCommune, '31591')
+  t.is(currentRevision.body.status, 'published')
+  t.is(currentRevision.body.current, true)
+
+  await request(server)
+    .get(`/revisions/${revisionIdA}`)
     .set('Authorization', 'Token foobar')
     .expect(404)
 })

--- a/lib/revisions/__tests__/integration.js
+++ b/lib/revisions/__tests__/integration.js
@@ -152,7 +152,7 @@ test.serial('basic revision', async t => {
   t.is(res7.body[0]._id, revisionId)
 })
 
-test.serial('remove files from revision', async t => {
+test.serial('remove revision and files', async t => {
   const server = await getApp({clients: [fakeClient]})
 
   const res1 = await request(server)
@@ -197,17 +197,28 @@ test.serial('remove files from revision', async t => {
   t.is(res3.body.files[0].hash, '8e67eef2db54dc96c3165060e4dc3b5239fcf82f7e61e3d72e72dfdf9ae2b16c')
 
   const res4 = await request(server)
-    .delete(`/revisions/${revisionId}`)
-    .set('Authorization', 'Token foobarAdmin')
-    .expect(200)
-
-  t.is(res4.body._id, revisionId)
-  t.is(res4.body.files, undefined)
-
-  const res5 = await request(server)
-    .get(`/revisions/${revisionId}`)
+    .post(`/revisions/${revisionId}/compute`)
     .set('Authorization', 'Token foobar')
     .expect(200)
 
-  t.is(res5.body.files.length, 0)
+  t.is(res4.body.validation.valid, true)
+  t.is(res4.body.ready, true)
+
+  const res5 = await request(server)
+    .post(`/revisions/${revisionId}/publish`)
+    .set('Authorization', 'Token foobar')
+    .expect(200)
+
+  t.is(res5.body.status, 'published')
+  t.is(res5.body.current, true)
+
+  await request(server)
+    .delete(`/revisions/${revisionId}`)
+    .set('Authorization', 'Token foobarAdmin')
+    .expect(204)
+
+  await request(server)
+    .get(`/revisions/${revisionId}`)
+    .set('Authorization', 'Token foobar')
+    .expect(404)
 })

--- a/lib/revisions/__tests__/integration.js
+++ b/lib/revisions/__tests__/integration.js
@@ -52,7 +52,7 @@ test('authentication / success', async t => {
 })
 
 test('admin authentication / success', async t => {
-  const server = await getApp()
+  const server = await getApp({clients: [fakeClient]})
   await request(server)
     .get('/admin')
     .set('Authorization', 'Token foobarAdmin')
@@ -72,7 +72,7 @@ test('authentication / fail', async t => {
 })
 
 test('admin authentication / fail', async t => {
-  const server = await getApp()
+  const server = await getApp({clients: [fakeClient]})
   await request(server)
     .get('/admin')
     .set('Authorization', 'Token foobar')

--- a/lib/revisions/model.js
+++ b/lib/revisions/model.js
@@ -98,10 +98,15 @@ async function updateLastRevisionToCurrent(codeCommune) {
     .toArray()
 
   if (lastRevision) {
-    await mongo.db.collection('revisions').updateOne(
+    const {value} = await mongo.db.collection('revisions').findOneAndUpdate(
       {_id: lastRevision._id},
-      {$set: {current: true, updatedAt: new Date()}}
+      {$set: {current: true, updatedAt: new Date()}},
+      {returnDocument: 'after'}
     )
+
+    console.log('Dernière révision :', value)
+  } else {
+    console.log(`Il n’y a pas de révision en cours pour la commune ${codeCommune}`)
   }
 }
 

--- a/lib/revisions/model.js
+++ b/lib/revisions/model.js
@@ -71,14 +71,38 @@ async function getFileData(fileId) {
   return file.data.buffer
 }
 
-async function removeFiles(revision) {
-  await mongo.db.collection('files').deleteMany({revisionId: revision._id})
-  await mongo.db.collection('revisions').updateOne(
-    {_id: revision._id},
-    {$set: {updatedAt: new Date()}}
-  )
+async function removeCurrentRevision(revisionId) {
+  await mongo.db.collection('files').deleteMany({revisionId})
+  await mongo.db.collection('revisions').deleteOne({_id: revisionId})
+}
 
-  return revision
+async function removePendingRevisions(codeCommune) {
+  await mongo.db.collection('revisions').deleteMany(
+    {
+      codeCommune,
+      status: 'pending',
+      ready: true
+    }
+  )
+}
+
+async function updateLastRevisionToCurrent(codeCommune) {
+  const [lastRevision] = await mongo.db.collection('revisions').find(
+    {
+      codeCommune,
+      status: 'published',
+      'validation.valid': {$eq: true}
+    })
+    .sort({publishedAt: -1})
+    .limit(1)
+    .toArray()
+
+  if (lastRevision) {
+    await mongo.db.collection('revisions').updateOne(
+      {_id: lastRevision._id},
+      {$set: {current: true, updatedAt: new Date()}}
+    )
+  }
 }
 
 async function computeRevision(revision) {
@@ -212,7 +236,9 @@ module.exports = {
   setFile,
   getFiles,
   getFileData,
-  removeFiles,
+  removeCurrentRevision,
+  removePendingRevisions,
+  updateLastRevisionToCurrent,
   publishRevision,
   fetchRevision,
   getCurrentRevision,

--- a/lib/revisions/model.js
+++ b/lib/revisions/model.js
@@ -71,6 +71,16 @@ async function getFileData(fileId) {
   return file.data.buffer
 }
 
+async function removeFiles(revision) {
+  await mongo.db.collection('files').deleteMany({revisionId: revision._id})
+  await mongo.db.collection('revisions').updateOne(
+    {_id: revision._id},
+    {$set: {updatedAt: new Date()}}
+  )
+
+  return revision
+}
+
 async function computeRevision(revision) {
   const files = await getFiles(revision)
   const balFiles = files.filter(f => f.type === 'bal')
@@ -202,6 +212,7 @@ module.exports = {
   setFile,
   getFiles,
   getFileData,
+  removeFiles,
   publishRevision,
   fetchRevision,
   getCurrentRevision,

--- a/lib/revisions/routes.js
+++ b/lib/revisions/routes.js
@@ -2,12 +2,12 @@ const express = require('express')
 const {isString, isPlainObject} = require('lodash')
 const createError = require('http-errors')
 const errorHandler = require('../util/error-handler')
-const {ensureCodeCommune, ensureCommuneActuelle} = require('../util/middlewares')
+const {ensureCodeCommune, ensureCommuneActuelle, ensureIsAdmin} = require('../util/middlewares')
 const w = require('../util/w')
 const rawBodyParser = require('../util/raw-body-parser')
 const {createAuthClient} = require('../clients')
 const {validateBAL} = require('./validate-bal')
-const {fetchRevision, getCurrentRevision, getRevisionsByCommune, createRevision, setFile, getFiles, getFileData, publishRevision, computeRevision, getCurrentRevisions, getRelatedHabilitation} = require('./model')
+const {fetchRevision, getCurrentRevision, getRevisionsByCommune, createRevision, setFile, getFiles, getFileData, removeFiles, publishRevision, computeRevision, getCurrentRevisions, getRelatedHabilitation} = require('./model')
 
 async function revisionsRoutes(params = {}) {
   const app = new express.Router()
@@ -105,6 +105,11 @@ async function revisionsRoutes(params = {}) {
     res.send({...req.revision, files})
   }))
 
+  app.delete('/revisions/:revisionId', ensureIsAdmin, w(async (req, res) => {
+    const revision = await removeFiles(req.revision)
+    res.send(revision)
+  }))
+
   app.put('/revisions/:revisionId/files/bal', authClient, rawBodyParser(), w(async (req, res) => {
     if (req.revision.status !== 'pending') {
       throw createError(412, 'La révision n’est plus modifiable')
@@ -173,6 +178,10 @@ async function revisionsRoutes(params = {}) {
 
   app.get('/me', authClient, (req, res) => {
     res.send(req.client)
+  })
+
+  app.get('/admin', ensureIsAdmin, (req, res) => {
+    res.sendStatus(200)
   })
 
   app.use(errorHandler)

--- a/lib/revisions/routes.js
+++ b/lib/revisions/routes.js
@@ -7,7 +7,7 @@ const w = require('../util/w')
 const rawBodyParser = require('../util/raw-body-parser')
 const {createAuthClient} = require('../clients')
 const {validateBAL} = require('./validate-bal')
-const {fetchRevision, getCurrentRevision, getRevisionsByCommune, createRevision, setFile, getFiles, getFileData, removeFiles, publishRevision, computeRevision, getCurrentRevisions, getRelatedHabilitation} = require('./model')
+const {fetchRevision, getCurrentRevision, getRevisionsByCommune, createRevision, setFile, getFiles, getFileData, publishRevision, computeRevision, getCurrentRevisions, getRelatedHabilitation, removeCurrentRevision, removePendingRevisions, updateLastRevisionToCurrent} = require('./model')
 
 async function revisionsRoutes(params = {}) {
   const app = new express.Router()
@@ -106,8 +106,15 @@ async function revisionsRoutes(params = {}) {
   }))
 
   app.delete('/revisions/:revisionId', ensureIsAdmin, w(async (req, res) => {
-    const revision = await removeFiles(req.revision)
-    res.send(revision)
+    if (req.revision.status !== 'published' || !req.revision.current) {
+      throw createError(412, 'Ne correspond pas à la dernière révision. Ne peut pas être supprimée')
+    }
+
+    await removeCurrentRevision(req.revision._id)
+    await removePendingRevisions(req.revision.codeCommune)
+    await updateLastRevisionToCurrent(req.revision.codeCommune)
+
+    res.sendStatus(204)
   }))
 
   app.put('/revisions/:revisionId/files/bal', authClient, rawBodyParser(), w(async (req, res) => {

--- a/lib/util/middlewares.js
+++ b/lib/util/middlewares.js
@@ -1,7 +1,7 @@
 const createError = require('http-errors')
 const {isCommuneActuelle, isCommune} = require('./cog')
 
-const ADMIN_TOKEN = process.env.ADMIN_TOKEN || 'xxxxxxxxxxxxxxx'
+const ADMIN_TOKEN = process.env.ADMIN_TOKEN
 
 function ensureCodeCommune(req, res, next) {
   if (!isCommune(req.params.codeCommune)) {
@@ -21,6 +21,10 @@ function ensureCommuneActuelle(req, res, next) {
 }
 
 function ensureIsAdmin(req, res, next) {
+  if (!ADMIN_TOKEN) {
+    return next(createError(400, 'ADMIN_TOKEN est obligatoire'))
+  }
+
   if (req.get('Authorization') !== `Token ${ADMIN_TOKEN}`) {
     return next(createError(401, 'Vous n’êtes pas autorisé à effectuer cette action'))
   }

--- a/lib/util/middlewares.js
+++ b/lib/util/middlewares.js
@@ -1,6 +1,8 @@
 const createError = require('http-errors')
 const {isCommuneActuelle, isCommune} = require('./cog')
 
+const ADMIN_TOKEN = process.env.ADMIN_TOKEN
+
 function ensureCodeCommune(req, res, next) {
   if (!isCommune(req.params.codeCommune)) {
     return next(createError(404, 'Le code commune n’existe pas'))
@@ -18,4 +20,12 @@ function ensureCommuneActuelle(req, res, next) {
   next()
 }
 
-module.exports = {ensureCodeCommune, ensureCommuneActuelle}
+function ensureIsAdmin(req, res, next) {
+  if (req.get('Authorization') !== `Token ${ADMIN_TOKEN}`) {
+    return next(createError(401, 'Vous n’êtes pas autorisé à effectuer cette action'))
+  }
+
+  next()
+}
+
+module.exports = {ensureCodeCommune, ensureCommuneActuelle, ensureIsAdmin}

--- a/lib/util/middlewares.js
+++ b/lib/util/middlewares.js
@@ -1,7 +1,7 @@
 const createError = require('http-errors')
 const {isCommuneActuelle, isCommune} = require('./cog')
 
-const ADMIN_TOKEN = process.env.ADMIN_TOKEN
+const ADMIN_TOKEN = process.env.ADMIN_TOKEN || 'xxxxxxxxxxxxxxx'
 
 function ensureCodeCommune(req, res, next) {
   if (!isCommune(req.params.codeCommune)) {


### PR DESCRIPTION
### Remplace la PR #34 
Resolves #33 

- Ajout de la variable d'environnement `ADMIN_TOKEN`
- Création de `ensureIsAdmin`, qui permet d'authentifier l'admin
- Création de la route `DELETE /revisions/:revisionId`
- Mise à jour des tests
