### PR TITLE
Expose les propriétés client.id et client.nom de la liste des révisions en cours

### DIFF
--- a/lib/revisions/model.js
+++ b/lib/revisions/model.js
@@ -193,7 +193,7 @@ function getCurrentRevisions(publishedSince) {
 
   return mongo.db.collection('revisions')
     .find({current: true, ...publishedSinceQuery})
-    .project({codeCommune: 1, publishedAt: 1})
+    .project({codeCommune: 1, publishedAt: 1, 'client.id': 1, 'client.nom': 1})
     .toArray()
 }
 


### PR DESCRIPTION
- Route concernée : `GET /current-revisions`

- Modification de la fonction `getCurrentRevisions` 

retourne : 
```json
[
 {
  "_id": "ObjectId",
  "codeCommune": "string",
  "client": {
   "id": "string",
   "nom": "string"
   },
  "publishedAt": "Date"
 },
 {
   "..."
  },
]
```