### PR TITLE
Ajout du modèle ChefDeFile

### DIFF
--- a/lib/chefs-de-file/__tests__/model.js
+++ b/lib/chefs-de-file/__tests__/model.js
@@ -1,0 +1,106 @@
+const test = require('ava')
+const {MongoMemoryServer} = require('mongodb-memory-server')
+const mongo = require('../../util/mongo')
+const ChefDeFile = require('../model')
+
+let mongod
+
+const keys = ['_id', 'nom', 'email', 'perimetreConvention', 'signataireCharte', '_createdAt', '_updatedAt']
+
+test.before('start server', async () => {
+  mongod = await MongoMemoryServer.create()
+  await mongo.connect(mongod.getUri())
+})
+
+test.after.always('cleanup', async () => {
+  await mongo.disconnect()
+  await mongod.stop()
+})
+
+test.afterEach.always(async () => {
+  await mongo.db.collection('chefs_de_file').deleteMany({})
+})
+
+test.serial('create chefDeFile', async t => {
+  const chefDeFile = await ChefDeFile.create({
+    nom: 'ACME',
+    email: 'iadresses@acme.ltd',
+    perimetreConvention: ['epci-246800726'],
+    signataireCharte: true
+  })
+
+  t.true(keys.every(k => k in chefDeFile))
+  t.is(Object.keys(chefDeFile).length, 7)
+  t.is(chefDeFile.nom, 'ACME')
+  t.is(chefDeFile.email, 'iadresses@acme.ltd')
+  t.deepEqual(chefDeFile.perimetreConvention, ['epci-246800726'])
+  t.is(chefDeFile.signataireCharte, true)
+})
+
+test.serial('create chefDeFile / minimal', async t => {
+  const chefDeFile = await ChefDeFile.create({
+    nom: 'ACME',
+    email: 'iadresses@acme.ltd',
+    perimetreConvention: ['commune-27115']
+  })
+
+  t.true(keys.every(k => k in chefDeFile))
+  t.is(Object.keys(chefDeFile).length, 7)
+  t.is(chefDeFile.nom, 'ACME')
+  t.is(chefDeFile.email, 'iadresses@acme.ltd')
+  t.deepEqual(chefDeFile.perimetreConvention, ['commune-27115'])
+  t.is(chefDeFile.signataireCharte, false)
+})
+
+test.serial('create chefDeFile / invalid perimetreConvention', async t => t.throwsAsync(() => ChefDeFile.create({
+    nom: 'ACME',
+    email: 'iadresses@acme.ltd',
+    perimetreConvention: ['27115']
+  })))
+
+test.serial('update chefDeFile', async t => {
+  const now = new Date()
+  const _id = new mongo.ObjectId()
+
+  await mongo.db.collection('chefs_de_file').insertOne({
+    _id,
+    nom: 'ACME',
+    email: 'iadresses@acme.ltd',
+    perimetreConvention: ['departement-14'],
+    signataireCharte: false,
+    _createdAt: now,
+    _updatedAt: now
+  })
+
+  const chefDeFile = await ChefDeFile.update(_id, {
+    nom: 'nouveau nom',
+    email: 'nouveau@mail.fr',
+    perimetreConvention: ['departement-27'],
+    signataireCharte: true
+  })
+  t.deepEqual(chefDeFile._id, _id)
+  t.deepEqual(chefDeFile._createdAt, now)
+  t.notDeepEqual(chefDeFile._updatedAt, now)
+  t.is(chefDeFile.nom, 'nouveau nom')
+  t.is(chefDeFile.email, 'nouveau@mail.fr')
+  t.deepEqual(chefDeFile.perimetreConvention, ['departement-27'])
+  t.is(chefDeFile.signataireCharte, true)
+})
+
+test.serial('update chefDeFile / extra param', async t => {
+  const now = new Date()
+  const _id = new mongo.ObjectId()
+
+  await mongo.db.collection('chefs_de_file').insertOne({
+    _id,
+    nom: 'ACME',
+    email: 'iadresses@acme.ltd',
+    perimetreConvention: ['27115'],
+    signataireCharte: false,
+    _createdAt: now,
+    _updatedAt: now
+  })
+
+  await t.throwsAsync(ChefDeFile.update(_id, {foo: 'bar'}))
+})
+

--- a/lib/chefs-de-file/__tests__/model.js
+++ b/lib/chefs-de-file/__tests__/model.js
@@ -5,7 +5,7 @@ const ChefDeFile = require('../model')
 
 let mongod
 
-const keys = ['_id', 'nom', 'email', 'perimetreConvention', 'signataireCharte', '_createdAt', '_updatedAt']
+const keys = ['_id', 'nom', 'email', 'perimetre', 'signataireCharte', '_createdAt', '_updatedAt']
 
 test.before('start server', async () => {
   mongod = await MongoMemoryServer.create()
@@ -25,7 +25,7 @@ test.serial('create chefDeFile', async t => {
   const chefDeFile = await ChefDeFile.create({
     nom: 'ACME',
     email: 'iadresses@acme.ltd',
-    perimetreConvention: ['epci-246800726'],
+    perimetre: ['epci-246800726'],
     signataireCharte: true
   })
 
@@ -33,7 +33,7 @@ test.serial('create chefDeFile', async t => {
   t.is(Object.keys(chefDeFile).length, 7)
   t.is(chefDeFile.nom, 'ACME')
   t.is(chefDeFile.email, 'iadresses@acme.ltd')
-  t.deepEqual(chefDeFile.perimetreConvention, ['epci-246800726'])
+  t.deepEqual(chefDeFile.perimetre, ['epci-246800726'])
   t.is(chefDeFile.signataireCharte, true)
 })
 
@@ -41,22 +41,26 @@ test.serial('create chefDeFile / minimal', async t => {
   const chefDeFile = await ChefDeFile.create({
     nom: 'ACME',
     email: 'iadresses@acme.ltd',
-    perimetreConvention: ['commune-27115']
+    perimetre: ['commune-27115']
   })
 
   t.true(keys.every(k => k in chefDeFile))
   t.is(Object.keys(chefDeFile).length, 7)
   t.is(chefDeFile.nom, 'ACME')
   t.is(chefDeFile.email, 'iadresses@acme.ltd')
-  t.deepEqual(chefDeFile.perimetreConvention, ['commune-27115'])
+  t.deepEqual(chefDeFile.perimetre, ['commune-27115'])
   t.is(chefDeFile.signataireCharte, false)
 })
 
-test.serial('create chefDeFile / invalid perimetreConvention', async t => t.throwsAsync(() => ChefDeFile.create({
+test.serial('create chefDeFile / invalid perimetre', async t => {
+  const chefDeFile = {
     nom: 'ACME',
     email: 'iadresses@acme.ltd',
-    perimetreConvention: ['27115']
-  })))
+    perimetre: ['27115']
+  }
+
+  await t.throwsAsync(() => ChefDeFile.create(chefDeFile))
+})
 
 test.serial('update chefDeFile', async t => {
   const now = new Date()
@@ -66,7 +70,7 @@ test.serial('update chefDeFile', async t => {
     _id,
     nom: 'ACME',
     email: 'iadresses@acme.ltd',
-    perimetreConvention: ['departement-14'],
+    perimetre: ['departement-14'],
     signataireCharte: false,
     _createdAt: now,
     _updatedAt: now
@@ -75,7 +79,7 @@ test.serial('update chefDeFile', async t => {
   const chefDeFile = await ChefDeFile.update(_id, {
     nom: 'nouveau nom',
     email: 'nouveau@mail.fr',
-    perimetreConvention: ['departement-27'],
+    perimetre: ['departement-27'],
     signataireCharte: true
   })
   t.deepEqual(chefDeFile._id, _id)
@@ -83,7 +87,7 @@ test.serial('update chefDeFile', async t => {
   t.notDeepEqual(chefDeFile._updatedAt, now)
   t.is(chefDeFile.nom, 'nouveau nom')
   t.is(chefDeFile.email, 'nouveau@mail.fr')
-  t.deepEqual(chefDeFile.perimetreConvention, ['departement-27'])
+  t.deepEqual(chefDeFile.perimetre, ['departement-27'])
   t.is(chefDeFile.signataireCharte, true)
 })
 
@@ -95,7 +99,7 @@ test.serial('update chefDeFile / extra param', async t => {
     _id,
     nom: 'ACME',
     email: 'iadresses@acme.ltd',
-    perimetreConvention: ['27115'],
+    perimetre: ['27115'],
     signataireCharte: false,
     _createdAt: now,
     _updatedAt: now

--- a/lib/chefs-de-file/__tests__/routes.js
+++ b/lib/chefs-de-file/__tests__/routes.js
@@ -1,0 +1,152 @@
+require('dotenv').config()
+
+process.env.ADMIN_TOKEN = 'xxxxxxxxxxxxxxx'
+
+const test = require('ava')
+const express = require('express')
+const request = require('supertest')
+const {MongoMemoryServer} = require('mongodb-memory-server')
+const mongo = require('../../util/mongo')
+const {chefsDeFileRoutes} = require('../routes')
+
+let mongod
+
+test.before('start server', async () => {
+  mongod = await MongoMemoryServer.create()
+  await mongo.connect(mongod.getUri())
+})
+
+test.after.always('cleanup', async () => {
+  await mongo.disconnect()
+  await mongod.stop()
+})
+
+test.afterEach.always(async () => {
+  await mongo.db.collection('chefs_de_file').deleteMany({})
+})
+
+async function getApp(params) {
+  const app = express()
+  const routes = await chefsDeFileRoutes(params)
+  app.use(routes)
+
+  return app
+}
+
+test.serial('create chefDeFile', async t => {
+  const server = await getApp()
+  const res = await request(server)
+    .post('/chefs-de-file')
+    .set('Authorization', `Token ${process.env.ADMIN_TOKEN}`)
+    .send({
+      nom: 'ACME',
+      email: 'iadresses@acme.ltd',
+      perimetreConvention: ['commune-27115'],
+      signataireCharte: true
+    })
+    .expect(201)
+
+  t.is(res.body.nom, 'ACME')
+  t.is(res.body.email, 'iadresses@acme.ltd')
+  t.deepEqual(res.body.perimetreConvention, ['commune-27115'])
+  t.is(res.body.signataireCharte, true)
+})
+
+test.serial('create chefDeFile / not admin', async t => {
+  const server = await getApp()
+  const res = await request(server)
+    .post('/chefs-de-file')
+    .send({
+      nom: 'ACME',
+      email: 'iadresses@acme.ltd',
+      perimetreConvention: ['commune-27115'],
+      signataireCharte: true
+    })
+    .expect(401)
+
+  t.deepEqual(res.body, {})
+})
+
+test.serial('update chefDeFile', async t => {
+  const _id = new mongo.ObjectId()
+  await mongo.db.collection('chefs_de_file').insertOne({
+    _id,
+    nom: 'ACME',
+    email: 'iadresses@acme.ltd',
+    perimetreConvention: ['commune-27115'],
+    signataireCharte: false
+  })
+
+  const server = await getApp()
+  const res = await request(server)
+    .put(`/chefs-de-file/${_id}`)
+    .set('Authorization', `Token ${process.env.ADMIN_TOKEN}`)
+    .send({
+      signataireCharte: true
+    })
+    .expect(200)
+
+  t.is(res.body.signataireCharte, true)
+})
+
+test.serial('update chefDeFile / not admin', async t => {
+  const _id = new mongo.ObjectId()
+  await mongo.db.collection('chefs_de_file').insertOne({
+    _id,
+    nom: 'ACME',
+    email: 'iadresses@acme.ltd',
+    perimetreConvention: ['commune-27115'],
+    signataireCharte: false
+  })
+
+  const server = await getApp()
+  const res = await request(server)
+    .put(`/chefs-de-file/${_id}`)
+    .send({
+      signataireCharte: true
+    })
+    .expect(401)
+
+  t.deepEqual(res.body, {})
+})
+
+test.serial('fetch chefDeFile', async t => {
+  const _id = new mongo.ObjectId()
+  await mongo.db.collection('chefs_de_file').insertOne({
+    _id,
+    nom: 'ACME',
+    email: 'iadresses@acme.ltd',
+    perimetreConvention: ['commune-27115'],
+    signataireCharte: false
+  })
+
+  const server = await getApp()
+  const res = await request(server)
+    .get(`/chefs-de-file/${_id}`)
+    .set('Authorization', `Token ${process.env.ADMIN_TOKEN}`)
+    .expect(200)
+
+  t.is(res.body.nom, 'ACME')
+  t.is(res.body.email, 'iadresses@acme.ltd')
+  t.deepEqual(res.body.perimetreConvention, ['commune-27115'])
+  t.is(res.body.signataireCharte, false)
+})
+
+test.serial('fetch chefDeFile / not admin', async t => {
+  const _id = new mongo.ObjectId()
+  const chefDeFile = {
+    _id,
+    nom: 'ACME',
+    organisme: 'ACME SARL',
+    email: 'me@domain.co',
+    token: 'foobar'
+  }
+  await mongo.db.collection('chefs_de_file').insertOne(chefDeFile)
+
+  const server = await getApp()
+  const res = await request(server)
+    .get(`/chefs-de-file/${_id}`)
+    .expect(401)
+
+  t.deepEqual(res.body, {})
+})

--- a/lib/chefs-de-file/__tests__/routes.js
+++ b/lib/chefs-de-file/__tests__/routes.js
@@ -41,14 +41,14 @@ test.serial('create chefDeFile', async t => {
     .send({
       nom: 'ACME',
       email: 'iadresses@acme.ltd',
-      perimetreConvention: ['commune-27115'],
+      perimetre: ['commune-27115'],
       signataireCharte: true
     })
     .expect(201)
 
   t.is(res.body.nom, 'ACME')
   t.is(res.body.email, 'iadresses@acme.ltd')
-  t.deepEqual(res.body.perimetreConvention, ['commune-27115'])
+  t.deepEqual(res.body.perimetre, ['commune-27115'])
   t.is(res.body.signataireCharte, true)
 })
 
@@ -59,12 +59,12 @@ test.serial('create chefDeFile / not admin', async t => {
     .send({
       nom: 'ACME',
       email: 'iadresses@acme.ltd',
-      perimetreConvention: ['commune-27115'],
+      perimetre: ['commune-27115'],
       signataireCharte: true
     })
     .expect(401)
 
-  t.deepEqual(res.body, {})
+  t.is(res.body.message, 'Vous n’êtes pas autorisé à effectuer cette action')
 })
 
 test.serial('update chefDeFile', async t => {
@@ -73,7 +73,7 @@ test.serial('update chefDeFile', async t => {
     _id,
     nom: 'ACME',
     email: 'iadresses@acme.ltd',
-    perimetreConvention: ['commune-27115'],
+    perimetre: ['commune-27115'],
     signataireCharte: false
   })
 
@@ -95,7 +95,7 @@ test.serial('update chefDeFile / not admin', async t => {
     _id,
     nom: 'ACME',
     email: 'iadresses@acme.ltd',
-    perimetreConvention: ['commune-27115'],
+    perimetre: ['commune-27115'],
     signataireCharte: false
   })
 
@@ -107,7 +107,7 @@ test.serial('update chefDeFile / not admin', async t => {
     })
     .expect(401)
 
-  t.deepEqual(res.body, {})
+  t.is(res.body.message, 'Vous n’êtes pas autorisé à effectuer cette action')
 })
 
 test.serial('fetch chefDeFile', async t => {
@@ -116,7 +116,7 @@ test.serial('fetch chefDeFile', async t => {
     _id,
     nom: 'ACME',
     email: 'iadresses@acme.ltd',
-    perimetreConvention: ['commune-27115'],
+    perimetre: ['commune-27115'],
     signataireCharte: false
   })
 
@@ -128,7 +128,7 @@ test.serial('fetch chefDeFile', async t => {
 
   t.is(res.body.nom, 'ACME')
   t.is(res.body.email, 'iadresses@acme.ltd')
-  t.deepEqual(res.body.perimetreConvention, ['commune-27115'])
+  t.deepEqual(res.body.perimetre, ['commune-27115'])
   t.is(res.body.signataireCharte, false)
 })
 
@@ -148,5 +148,5 @@ test.serial('fetch chefDeFile / not admin', async t => {
     .get(`/chefs-de-file/${_id}`)
     .expect(401)
 
-  t.deepEqual(res.body, {})
+  t.is(res.body.message, 'Vous n’êtes pas autorisé à effectuer cette action')
 })

--- a/lib/chefs-de-file/model.js
+++ b/lib/chefs-de-file/model.js
@@ -1,0 +1,88 @@
+const createError = require('http-errors')
+const Joi = require('joi')
+const mongo = require('../util/mongo')
+const {validPayload} = require('../util/payload')
+const {isEPCI, isDepartement, isCommune} = require('../util/cog')
+
+function validPerimetre(perimetreConvention) {
+  const [territoireType, code] = perimetreConvention.split('-')
+  if (!['epci', 'departement', 'commune'].includes(territoireType)) {
+    throw new Error('Le type du terrioire est invalide')
+  }
+
+  if (territoireType === 'commune' && !isCommune(code)) {
+    throw new Error('Le code commune est invalide')
+  }
+
+  if (territoireType === 'departement' && !isDepartement(code)) {
+    throw new Error('Le code département est invalide')
+  }
+
+  if (territoireType === 'epci' && !isEPCI(code)) {
+    throw new Error('Le siren epci est invalide')
+  }
+
+  return perimetreConvention
+}
+
+const createSchema = Joi.object({
+  nom: Joi.string().min(3).max(200).required(),
+  email: Joi.string().email().required(),
+  perimetreConvention: Joi.array().items(Joi.string().custom(validPerimetre)).min(1).required(),
+  signataireCharte: Joi.boolean().default(false)
+})
+
+async function create(payload) {
+  const chefDefile = validPayload(payload, createSchema)
+
+  mongo.decorateCreation(chefDefile)
+
+  await mongo.db.collection('chefs_de_file').insertOne(chefDefile)
+
+  return chefDefile
+}
+
+const updateSchema = Joi.object({
+  nom: Joi.string().min(3).max(200),
+  email: Joi.string().email(),
+  perimetreConvention: Joi.array().items(Joi.string().custom(validPerimetre)).min(1),
+  signataireCharte: Joi.boolean()
+})
+
+async function update(id, payload) {
+  const chefDefile = validPayload(payload, updateSchema)
+
+  if (Object.keys(chefDefile).length === 0) {
+    throw createError(400, 'Le contenu de la requête est invalide (aucun champ valide trouvé)')
+  }
+
+  mongo.decorateModification(chefDefile)
+
+  const {value} = await mongo.db.collection('chefs_de_file').findOneAndUpdate(
+    {_id: mongo.parseObjectID(id)},
+    {$set: chefDefile},
+    {returnDocument: 'after'}
+  )
+
+  if (!value) {
+    throw createError(404, 'Le chef de file est introuvable')
+  }
+
+  return value
+}
+
+function fetch(chefDeFileId) {
+  chefDeFileId = mongo.parseObjectID(chefDeFileId)
+
+  if (!chefDeFileId) {
+    throw createError(404, 'L’identifiant du chef de file est invalide')
+  }
+
+  return mongo.db.collection('chefs_de_file').findOne({_id: chefDeFileId})
+}
+
+module.exports = {
+  create,
+  update,
+  fetch
+}

--- a/lib/chefs-de-file/model.js
+++ b/lib/chefs-de-file/model.js
@@ -4,8 +4,8 @@ const mongo = require('../util/mongo')
 const {validPayload} = require('../util/payload')
 const {isEPCI, isDepartement, isCommune} = require('../util/cog')
 
-function validPerimetre(perimetreConvention) {
-  const [territoireType, code] = perimetreConvention.split('-')
+function validPerimetre(perimetre) {
+  const [territoireType, code] = perimetre.split('-')
   if (!['epci', 'departement', 'commune'].includes(territoireType)) {
     throw new Error('Le type du terrioire est invalide')
   }
@@ -22,13 +22,13 @@ function validPerimetre(perimetreConvention) {
     throw new Error('Le siren epci est invalide')
   }
 
-  return perimetreConvention
+  return perimetre
 }
 
 const createSchema = Joi.object({
   nom: Joi.string().min(3).max(200).required(),
   email: Joi.string().email().required(),
-  perimetreConvention: Joi.array().items(Joi.string().custom(validPerimetre)).min(1).required(),
+  perimetre: Joi.array().items(Joi.string().custom(validPerimetre)).min(1).required(),
   signataireCharte: Joi.boolean().default(false)
 })
 
@@ -45,7 +45,7 @@ async function create(payload) {
 const updateSchema = Joi.object({
   nom: Joi.string().min(3).max(200),
   email: Joi.string().email(),
-  perimetreConvention: Joi.array().items(Joi.string().custom(validPerimetre)).min(1),
+  perimetre: Joi.array().items(Joi.string().custom(validPerimetre)).min(1),
   signataireCharte: Joi.boolean()
 })
 
@@ -81,8 +81,13 @@ function fetch(chefDeFileId) {
   return mongo.db.collection('chefs_de_file').findOne({_id: chefDeFileId})
 }
 
+async function fetchAll() {
+  return mongo.db.collection('chefs_de_file').find().toArray()
+}
+
 module.exports = {
   create,
   update,
-  fetch
+  fetch,
+  fetchAll
 }

--- a/lib/chefs-de-file/routes.js
+++ b/lib/chefs-de-file/routes.js
@@ -1,6 +1,5 @@
 const express = require('express')
 const createError = require('http-errors')
-const {isEqual} = require('lodash')
 const errorHandler = require('../util/error-handler')
 const {ensureIsAdmin} = require('../util/middlewares')
 const w = require('../util/w')
@@ -29,11 +28,6 @@ async function chefsDeFileRoutes() {
     }))
     .put(ensureIsAdmin, w(async (req, res) => {
       const chefDeFile = await ChefDeFile.update(req.chefDeFile._id, req.body)
-
-      if (isEqual(req.chefDeFile, chefDeFile)) {
-        return res.sendStatus(304)
-      }
-
       res.send(chefDeFile)
     }))
 

--- a/lib/chefs-de-file/routes.js
+++ b/lib/chefs-de-file/routes.js
@@ -1,0 +1,47 @@
+const express = require('express')
+const createError = require('http-errors')
+const {isEqual} = require('lodash')
+const {ensureIsAdmin} = require('../util/middlewares')
+const w = require('../util/w')
+const ChefDeFile = require('./model')
+
+async function chefsDeFileRoutes() {
+  const app = new express.Router()
+
+  app.use(express.json())
+
+  app.param('chefDeFileId', w(async (req, res, next) => {
+    const {chefDeFileId} = req.params
+    const chefDeFile = await ChefDeFile.fetch(chefDeFileId)
+
+    if (!chefDeFile) {
+      throw createError(404, 'L’identifiant de chefDeFile demandé n’existe pas')
+    }
+
+    req.chefDeFile = chefDeFile
+    next()
+  }))
+
+  app.route('/chefs-de-file/:chefDeFileId')
+    .get(ensureIsAdmin, w(async (req, res) => {
+      res.send(req.chefDeFile)
+    }))
+    .put(ensureIsAdmin, w(async (req, res) => {
+      const chefDeFile = await ChefDeFile.update(req.chefDeFile._id, req.body)
+
+      if (isEqual(req.chefDeFile, chefDeFile)) {
+        res.sendStatus(304)
+      }
+
+      res.send(chefDeFile)
+    }))
+
+  app.post('/chefs-de-file', ensureIsAdmin, w(async (req, res) => {
+    const chefDeFile = await ChefDeFile.create(req.body)
+    res.status(201).send(chefDeFile)
+  }))
+
+  return app
+}
+
+module.exports = {chefsDeFileRoutes}

--- a/lib/chefs-de-file/routes.js
+++ b/lib/chefs-de-file/routes.js
@@ -1,6 +1,7 @@
 const express = require('express')
 const createError = require('http-errors')
 const {isEqual} = require('lodash')
+const errorHandler = require('../util/error-handler')
 const {ensureIsAdmin} = require('../util/middlewares')
 const w = require('../util/w')
 const ChefDeFile = require('./model')
@@ -30,16 +31,23 @@ async function chefsDeFileRoutes() {
       const chefDeFile = await ChefDeFile.update(req.chefDeFile._id, req.body)
 
       if (isEqual(req.chefDeFile, chefDeFile)) {
-        res.sendStatus(304)
+        return res.sendStatus(304)
       }
 
       res.send(chefDeFile)
     }))
 
-  app.post('/chefs-de-file', ensureIsAdmin, w(async (req, res) => {
-    const chefDeFile = await ChefDeFile.create(req.body)
-    res.status(201).send(chefDeFile)
-  }))
+  app.route('/chefs-de-file')
+    .get(ensureIsAdmin, w(async (req, res) => {
+      const chefsDeFile = await ChefDeFile.fetchAll()
+      res.send(chefsDeFile)
+    }))
+    .post(ensureIsAdmin, w(async (req, res) => {
+      const chefDeFile = await ChefDeFile.create(req.body)
+      res.status(201).send(chefDeFile)
+    }))
+
+  app.use(errorHandler)
 
   return app
 }

--- a/lib/util/cog.js
+++ b/lib/util/cog.js
@@ -1,4 +1,6 @@
 const {keyBy} = require('lodash')
+const epcis = require('@etalab/decoupage-administratif/data/epci.json')
+const departements = require('@etalab/decoupage-administratif/data/departements.json')
 const communes = require('@etalab/decoupage-administratif/data/communes.json')
   .filter(c => ['commune-actuelle', 'arrondissement-municipal'].includes(c.type))
 
@@ -15,6 +17,16 @@ for (const commune of communes) {
   }
 }
 
+const codesEPCI = new Set()
+for (const epci of epcis) {
+  codesEPCI.add(epci.code)
+}
+
+const codesDepartement = new Set()
+for (const departement of departements) {
+  codesDepartement.add(departement.code)
+}
+
 function isCommune(codeCommune) {
   return codesCommunes.has(codeCommune)
 }
@@ -27,4 +39,19 @@ function getCommune(codeCommune) {
   return communesIndex[codeCommune]
 }
 
-module.exports = {communes, isCommune, isCommuneActuelle, getCommune}
+function isEPCI(siren) {
+  return codesEPCI.has(siren)
+}
+
+function isDepartement(codeDepartement) {
+  return codesDepartement.has(codeDepartement)
+}
+
+module.exports = {
+  isEPCI,
+  isDepartement,
+  communes,
+  isCommune,
+  isCommuneActuelle,
+  getCommune
+}

--- a/lib/util/cog.js
+++ b/lib/util/cog.js
@@ -17,15 +17,8 @@ for (const commune of communes) {
   }
 }
 
-const codesEPCI = new Set()
-for (const epci of epcis) {
-  codesEPCI.add(epci.code)
-}
-
-const codesDepartement = new Set()
-for (const departement of departements) {
-  codesDepartement.add(departement.code)
-}
+const codesEPCI = new Set(epcis.map(e => e.code))
+const codesDepartement = new Set(departements.map(d => d.code))
 
 function isCommune(codeCommune) {
   return codesCommunes.has(codeCommune)

--- a/lib/util/payload.js
+++ b/lib/util/payload.js
@@ -1,21 +1,6 @@
 const createHttpError = require('http-errors')
-const {pick, reduce} = require('lodash')
+const {pick} = require('lodash')
 const mongo = require('./mongo')
-
-class ValidationError extends Error {
-  constructor(validationDetails) {
-    super('Invalid payload')
-    this.validation = reduce(validationDetails, (acc, detail) => {
-      const key = detail.path[0]
-      if (!acc[key]) {
-        acc[key] = []
-      }
-
-      acc[key].push(detail.message)
-      return acc
-    }, {})
-  }
-}
 
 function validObjectID(id) {
   if (id) {
@@ -41,8 +26,7 @@ function validPayload(payload, schema) {
   })
 
   if (error) {
-    const validationError = new ValidationError(error.details)
-    throw createHttpError(400, validationError)
+    throw createHttpError(400, error)
   }
 
   return value
@@ -51,6 +35,5 @@ function validPayload(payload, schema) {
 module.exports = {
   getFilteredPayload,
   validPayload,
-  validObjectID,
-  ValidationError
+  validObjectID
 }

--- a/server.js
+++ b/server.js
@@ -8,6 +8,7 @@ const mongo = require('./lib/util/mongo')
 const {revisionsRoutes} = require('./lib/revisions/routes')
 const {habilitationsRoutes} = require('./lib/habilitations/routes')
 const {mandatairesRoutes} = require('./lib/mandataires/routes')
+const {chefsDeFileRoutes} = require('./lib/chefs-de-file/routes')
 
 async function main() {
   const app = express()
@@ -24,10 +25,12 @@ async function main() {
   const revisions = await revisionsRoutes()
   const habilitation = await habilitationsRoutes()
   const mandataires = await mandatairesRoutes()
+  const chefsDeFile = await chefsDeFileRoutes()
 
   app.use('/', revisions)
   app.use('/', habilitation)
   app.use('/', mandataires)
+  app.use('/', chefsDeFile)
 
   app.listen(port, () => {
     console.log(`Start listening on port ${port}`)


### PR DESCRIPTION
## Contexte
Cette PR prépare la migration du fichier `client.yml` sur mongodb en ajoutant un modèle `ChefDeFile` qui sera lié au prochain modèle `Client`.

### ChefDeFile
```
{
  _id: '7n51dae287088f21afd07c580',
  nom: 'Nom du chef de file',
  email: 'chefdefile@email.fr',
  perimetre: ['epci-246800726', 'departement-14', 'commune-27115'],
  signataireCharte: true,
  _createdAt: '1970-01-01',
  _updatedAt: '1970-01-01',
}
```

### Routes
> Toutes les routes nécéssitent une authentification administrateur

**`/chefs-de-file`**
- Créer un chef de file : `POST /chefs-de-file/`
- Récupérer un chef de file : `GET /chefs-de-file/:chefDeFileId`
- Modifier un chef de file : `PUT /chefs-de-file/:chefDeFileId`

-----
Cette PR est issue d'un découpage de #39 afin de faciliter la revue et l'intégration.