### PR TITLE
Augmente la taille autorisé des fichiers à 50mb

### DIFF
--- a/lib/util/raw-body-parser.js
+++ b/lib/util/raw-body-parser.js
@@ -8,7 +8,7 @@ const contentDisposition = require('content-disposition')
 
 const gunzip = promisify(zlib.gunzip)
 
-function rawBodyParser(maxBuffer = '10mb') {
+function rawBodyParser(maxBuffer = '50mb') {
   maxBuffer = typeof maxBuffer === 'string' ? bytes(maxBuffer) : maxBuffer
 
   return async (req, res, next) => {


### PR DESCRIPTION
## Contexte
La limite actuelle de `10mb` bloque actuellement les plus grosses communes. Cette PR augmente cette taille limite à `50mb`.