### PR TITLE
rendre generique la route de calcul de diffrentiel entre 2 révisions

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -18,4 +18,4 @@ SESSION_SECRET=foobar
 ADMIN_TOKEN=
 BAN_API_URL=https://plateforme.adresse.data.gouv.fr/ban
 BAN_API_TOKEN=
-NOTIFY_BAL=1
+NOTIFY_BAN=1

--- a/lib/revisions/routes.js
+++ b/lib/revisions/routes.js
@@ -159,22 +159,22 @@ async function revisionsRoutes(params = {}) {
     res.send(data)
   }
 
-  app.get('/revisions/:revisionId/calc-diff', w(async (req, res) => {
-    const myRevision = await fetchRevision(req.revision._id)
-    if (!myRevision) {
-      throw createError(404, 'L’identifiant de révision demandé n’existe pas')
+  app.get('/revisions/:revisionIdV0/:revisionIdV1/calc-diff', w(async (req, res) => {
+    const myRevisionV0 = await fetchRevision(req.params.revisionIdV0)
+    const myRevisionV1 = await fetchRevision(req.params.revisionIdV1)
+    if (!myRevisionV0) {
+      throw createError(404, 'L’identifiant de révision demandé n’existe pas : ' + req.params.revisionIdV0)
     }
 
-    const currentRevision = await getCurrentRevision(myRevision.codeCommune)
-    if (!currentRevision) {
-      throw createError(404, 'L’identifiant de révision demandé n’existe pas')
+    if (!myRevisionV1) {
+      throw createError(404, 'L’identifiant de révision demandé n’existe pas : ' + req.params.revisionIdV1)
     }
 
-    if (currentRevision._id === myRevision._id) {
-      throw createError(500, 'La révision donnée est déja la révision courante')
+    if (myRevisionV0._id === myRevisionV1._id) {
+      throw createError(500, 'Les révisions sont identiques')
     }
 
-    const resultDiff = await computeDiffBalFiles(await getObjFromRevision(myRevision), await getObjFromRevision(currentRevision))
+    const resultDiff = await computeDiffBalFiles(await getObjFromRevision(myRevisionV1), await getObjFromRevision(myRevisionV0))
 
     res.status(200).send(resultDiff)
   }))

--- a/lib/revisions/validate-bal.js
+++ b/lib/revisions/validate-bal.js
@@ -9,6 +9,8 @@ const strictModeAdditionalErrors = [
   'cle_interop.valeur_manquante',
   'cle_interop.numero_prefixe_manquant',
   'cle_interop.casse_invalide',
+  'uid.valeur_manquante',
+  'uid.structure_invalide',
   'numero.contient_prefixe',
   'suffixe.espaces_debut_fin',
   'commune_insee.valeur_manquante',
@@ -59,6 +61,7 @@ async function applyValidateBAL(file, codeCommune, options = {}) {
   }
 
   const errors = relaxMode ? baseErrors : union(baseErrors, strictModeAdditionalErrors)
+
   const warnings = relaxMode ? baseWarnings : difference(baseWarnings, strictModeAdditionalErrors)
   const infos = relaxMode ? baseInfos : difference(baseInfos, strictModeAdditionalErrors)
 

--- a/lib/revisions/validate-bal.js
+++ b/lib/revisions/validate-bal.js
@@ -9,8 +9,8 @@ const strictModeAdditionalErrors = [
   'cle_interop.valeur_manquante',
   'cle_interop.numero_prefixe_manquant',
   'cle_interop.casse_invalide',
-  'uid.valeur_manquante',
-  'uid.structure_invalide',
+  'uid_adresse.valeur_manquante',
+  'uid_adresse.structure_invalide',
   'numero.contient_prefixe',
   'suffixe.espaces_debut_fin',
   'commune_insee.valeur_manquante',
@@ -61,7 +61,6 @@ async function applyValidateBAL(file, codeCommune, options = {}) {
   }
 
   const errors = relaxMode ? baseErrors : union(baseErrors, strictModeAdditionalErrors)
-
   const warnings = relaxMode ? baseWarnings : difference(baseWarnings, strictModeAdditionalErrors)
   const infos = relaxMode ? baseInfos : difference(baseInfos, strictModeAdditionalErrors)
 


### PR DESCRIPTION
La route à tester : 
http://localhost:5000/revisions/:idRevisionV0/:idRevisionV1/calc-diff

permet d'avoir le différentiel entre 2 révisions, l'ordre des id de révision est important.
Les révisions n'ont pas besoin d'être publiées pour être comparées.

fix #52 
