### PR TITLE
PROTO ID:Exploiter un fichier des evènements fournis #30

### DIFF
--- a/lib/revisions/model.js
+++ b/lib/revisions/model.js
@@ -61,6 +61,25 @@ async function setFile(revision, type, {data, name}) {
   return omit(file, 'data')
 }
 
+async function setDiffBal(revision, type, {data}) {
+  const _id = new mongo.ObjectId()
+
+  const diffBal = {
+    _id,
+    revisionId: revision._id,
+    data,
+    size: data.length,
+    hash: hasha(data, {algorithm: 'sha256'}),
+
+    createdAt: new Date()
+  }
+
+  await mongo.db.collection('diff_bal').deleteOne({revisionId: revision._id, type})
+  await mongo.db.collection('diff_bal').insertOne(diffBal)
+
+  return omit(diffBal, 'data')
+}
+
 async function getFiles(revision) {
   return mongo.db.collection('files')
     .find({revisionId: revision._id})
@@ -210,6 +229,7 @@ function getCurrentRevisions(publishedSince) {
 module.exports = {
   createRevision,
   setFile,
+  setDiffBal,
   getFiles,
   getFileData,
   publishRevision,

--- a/lib/revisions/model.js
+++ b/lib/revisions/model.js
@@ -61,12 +61,13 @@ async function setFile(revision, type, {data, name}) {
   return omit(file, 'data')
 }
 
-async function setDiffBal(revision, {data}) {
+async function setDiffBal(revision,type, {data}) {
   const _id = new mongo.ObjectId()
 
   const diffBal = {
     _id,
     revisionId: revision._id,
+    type,
     data,
     size: data.length,
     hash: hasha(data, {algorithm: 'sha256'}),
@@ -74,7 +75,7 @@ async function setDiffBal(revision, {data}) {
     createdAt: new Date()
   }
 
-  await mongo.db.collection('diff_bal').deleteOne({revisionId: revision._id})
+  await mongo.db.collection('diff_bal').deleteOne({revisionId: revision._id, type})
   await mongo.db.collection('diff_bal').insertOne(diffBal)
 
   return omit(diffBal, 'data')

--- a/lib/revisions/model.js
+++ b/lib/revisions/model.js
@@ -61,7 +61,7 @@ async function setFile(revision, type, {data, name}) {
   return omit(file, 'data')
 }
 
-async function setDiffBal(revision, type, {data}) {
+async function setDiffBal(revision, {data}) {
   const _id = new mongo.ObjectId()
 
   const diffBal = {
@@ -74,7 +74,7 @@ async function setDiffBal(revision, type, {data}) {
     createdAt: new Date()
   }
 
-  await mongo.db.collection('diff_bal').deleteOne({revisionId: revision._id, type})
+  await mongo.db.collection('diff_bal').deleteOne({revisionId: revision._id})
   await mongo.db.collection('diff_bal').insertOne(diffBal)
 
   return omit(diffBal, 'data')

--- a/lib/revisions/routes.js
+++ b/lib/revisions/routes.js
@@ -7,7 +7,7 @@ const w = require('../util/w')
 const rawBodyParser = require('../util/raw-body-parser')
 const {createAuthClient} = require('../clients')
 const {validateBAL, applyValidateBAL} = require('./validate-bal')
-const {fetchRevision, getCurrentRevision, getRevisionsByCommune, createRevision, setFile, getFiles, getFileData, publishRevision, computeRevision, getCurrentRevisions, getRelatedHabilitation} = require('./model')
+const {fetchRevision, getCurrentRevision, getRevisionsByCommune, createRevision, setFile, setDiffBal, getFiles, getFileData, publishRevision, computeRevision, getCurrentRevisions, getRelatedHabilitation} = require('./model')
 
 async function revisionsRoutes(params = {}) {
   const app = new express.Router()
@@ -179,6 +179,23 @@ async function revisionsRoutes(params = {}) {
     res.status(200).send(resultDiff)
   }))
 
+  app.put('/revisions/:revisionId/files/diff-bal', authClient, rawBodyParser(), w(async (req, res) => {
+    const myRevision = await fetchRevision(req.params.revisionId)
+    if (!myRevision) {
+      throw createError(404, 'L’identifiant de révision demandé n’existe pas : ' + req.params.revisionIdV0)
+    }
+
+    if (!Buffer.isBuffer(req.body)) {
+      throw createError(400, 'Fichier json non fourni')
+    }
+
+    const file = await setDiffBal(req.revision, 'bal', {
+      data: req.body,
+      name: req.filename || null
+    })
+    res.send(file)
+  }))
+  
   app.get('/communes/:codeCommune/current-revision/files/bal/download', w(async (req, res) => {
     const revision = await getCurrentRevision(req.codeCommune)
 

--- a/lib/revisions/routes.js
+++ b/lib/revisions/routes.js
@@ -188,7 +188,7 @@ async function revisionsRoutes(params = {}) {
       throw createError(400, 'Fichier json non fourni')
     }
 
-    const file = await setDiffBal(req.revision, {
+    const file = await setDiffBal(req.revision, 'diff', {
       data: req.body,
       name: req.filename || null
     })

--- a/lib/revisions/routes.js
+++ b/lib/revisions/routes.js
@@ -180,12 +180,9 @@ async function revisionsRoutes(params = {}) {
   }))
 
   app.put('/revisions/:revisionId/files/diff-bal', authClient, rawBodyParser(), w(async (req, res) => {
-    const myRevision = await fetchRevision(req.params.revisionId)
-    if (!myRevision) {
-      throw createError(404, 'L’identifiant de révision demandé n’existe pas : ' + req.params.revisionIdV0)
-    }
+    const fileBody = req.body
 
-    if (!Buffer.isBuffer(req.body)) {
+    if (fileBody.length === 0) {
       throw createError(400, 'Fichier json non fourni')
     }
 
@@ -195,7 +192,7 @@ async function revisionsRoutes(params = {}) {
     })
     res.send(file)
   }))
-  
+
   app.get('/communes/:codeCommune/current-revision/files/bal/download', w(async (req, res) => {
     const revision = await getCurrentRevision(req.codeCommune)
 

--- a/lib/revisions/routes.js
+++ b/lib/revisions/routes.js
@@ -178,15 +178,17 @@ async function revisionsRoutes(params = {}) {
 
     res.status(200).send(resultDiff)
   }))
-
   app.put('/revisions/:revisionId/files/diff-bal', authClient, rawBodyParser(), w(async (req, res) => {
     const fileBody = req.body
+    if (req.revision.status === 'published') {
+      throw createError(403, 'Opération impossible, la révision est déja publiée')
+    }
 
     if (fileBody.length === 0) {
       throw createError(400, 'Fichier json non fourni')
     }
 
-    const file = await setDiffBal(req.revision, 'bal', {
+    const file = await setDiffBal(req.revision, {
       data: req.body,
       name: req.filename || null
     })

--- a/lib/util/mongo.js
+++ b/lib/util/mongo.js
@@ -27,6 +27,8 @@ class Mongo {
     await this.db.collection('habilitations').createIndex({codeCommune: 1})
 
     await this.db.collection('files').createIndex({revisionId: 1})
+
+    await this.db.collection('diff_bal').createIndex({revisionId: 1})
   }
 
   async disconnect(force) {


### PR DESCRIPTION
Créer une nouvelle route de l'API en PUT permettant de délivrer un fichier de type json permettant de préciser les suppressions de cette révision (count des idsupprimés et détail des id supprimés). voir l'issue #30 pour le détail

Fix #30 