### PR TITLE
modification route de compute pour comparer les ids supprimés déclarés et calculés

### DIFF
--- a/lib/revisions/routes.js
+++ b/lib/revisions/routes.js
@@ -1,6 +1,7 @@
 const express = require('express')
-const {isString, isPlainObject} = require('lodash')
+const {isString, isPlainObject, isUndefined} = require('lodash')
 const createError = require('http-errors')
+const {decodeBuffer} = require('@ban-team/validateur-bal/lib/validate/parse')
 const errorHandler = require('../util/error-handler')
 const {ensureCodeCommune, ensureCommuneActuelle} = require('../util/middlewares')
 const w = require('../util/w')
@@ -60,8 +61,7 @@ async function revisionsRoutes(params = {}) {
       suffixe,
       clef_interop: clefInterop
     }}) => {
-      // eslint-disable-next-line no-negated-condition
-      if (!acc[uidAdresse]) {
+      if (!acc[uidAdresse] && uidAdresse) {
         acc[uidAdresse] = {
           id: uidAdresse,
           sign: `${voieNom} - ${lieuditComplementNom} - ${numero} - ${suffixe} - ${clefInterop}`,
@@ -69,7 +69,7 @@ async function revisionsRoutes(params = {}) {
             ...getPosObject({pos, lon, lat})
           }
         }
-      } else {
+      } else if (uidAdresse) {
         acc[uidAdresse].positions = {
           ...acc[uidAdresse].positions,
           ...getPosObject({pos, lon, lat})
@@ -79,16 +79,41 @@ async function revisionsRoutes(params = {}) {
       return acc
     }, {}
     )
+
     return adresseObj
   }
 
+  function isEqualIds(IdsArray1, IdsArray2) {
+    if (IdsArray1?.length >= 0 && IdsArray2?.length >= 0) {
+      const {commonIds} = computeDiffIds(IdsArray1, IdsArray2)
+      if (commonIds?.length === IdsArray1?.length && commonIds?.length === IdsArray2?.length) {
+        return true
+      }
+    }
+
+    return false
+  }
+
+  function computeDiffIds(IdsArray1, IdsArray2) {
+    const newIds = IdsArray1.filter(item => !IdsArray2.includes(item))
+    const deletedIds = IdsArray2.filter(item => !IdsArray1.includes(item))
+    const commonIds = IdsArray2.filter(item => IdsArray1.includes(item))
+    return {
+      newIds,
+      deletedIds,
+      commonIds
+    }
+  }
+
   async function computeDiffBalFiles(adresseObjV1, adresseObjCurrent) {
+    if (Object.keys(adresseObjV1).length === 0) {
+      return undefined
+    }
+
     const idsV1 = Object.keys(adresseObjV1)
     const idsCurrent = Object.keys(adresseObjCurrent)
 
-    const newIds = idsV1.filter(item => !idsCurrent.includes(item))
-    const deletedIds = idsCurrent.filter(item => !idsV1.includes(item))
-    const commonIds = idsCurrent.filter(item => idsV1.includes(item))
+    const {newIds, deletedIds, commonIds} = await computeDiffIds(idsV1, idsCurrent)
 
     const modifiedIdsSem = []
     const modifiedIdsPos = []
@@ -175,7 +200,6 @@ async function revisionsRoutes(params = {}) {
     }
 
     const resultDiff = await computeDiffBalFiles(await getObjFromRevision(myRevisionV1), await getObjFromRevision(myRevisionV0))
-
     res.status(200).send(resultDiff)
   }))
   app.put('/revisions/:revisionId/files/diff-bal', authClient, rawBodyParser(), w(async (req, res) => {
@@ -187,6 +211,7 @@ async function revisionsRoutes(params = {}) {
     if (fileBody.length === 0) {
       throw createError(400, 'Fichier json non fourni')
     }
+
     const file = await setFile(req.revision, 'diff', {
       data: req.body,
       name: req.filename || null
@@ -290,9 +315,45 @@ async function revisionsRoutes(params = {}) {
       throw createError(412, 'La révision n’est plus modifiable')
     }
 
-    const computedRevision = await computeRevision(req.revision)
+    const myRevision = await fetchRevision(req.params.revisionId)
+    const currentRevision = await getCurrentRevision(myRevision.codeCommune)
+    // Si on a une current revision on poursuit
+    if (currentRevision) {
+      if (myRevision._id === currentRevision._id) {
+        throw createError(500, 'Les révisions sont identiques')
+      }
 
-    res.send(computedRevision)
+      const resultDiff = await computeDiffBalFiles(await getObjFromRevision(myRevision), await getObjFromRevision(currentRevision))
+      // ResultDiff est undefined on n'a pas d'identifiant on fait le process habituel
+      if (isUndefined(resultDiff)) {
+        const computedRevision = await computeRevision(req.revision)
+        res.send(computedRevision)
+      } else {
+        // Sinon on calcule on compare avec le diff déclaré
+        const files = await getFiles(myRevision)
+        const diffFiles = files.filter(f => f.type === 'diff')
+        if (diffFiles.length !== 1) {
+          throw createError(400, 'Un fichier de type `diff` doit être fourni')
+        }
+
+        const deletedIdsComputed = []
+        deletedIdsComputed.push(...resultDiff.deletedIds)
+        const {decodedString} = decodeBuffer(await getFileData(diffFiles[0]._id))
+        const deletedIdsFromUser = []
+        deletedIdsFromUser.push(...JSON.parse(decodedString).deletedIds)
+        const isSameDeleted = isEqualIds(deletedIdsFromUser, deletedIdsComputed)
+        // Si les ids supprimés sont les mêmes que ceux déclarés on permet le compute habituel
+        if (isSameDeleted) {
+          const computedRevision = await computeRevision(req.revision)
+          res.send(computedRevision)
+        } else {
+          throw createError(400, 'les identifiants des adresses supprimées calculés et déclarés ne sont pas identiques.')
+        }
+      }
+    } else {// Si pas encore de current revision on fait le processus habituel
+      const computedRevision = await computeRevision(req.revision)
+      res.send(computedRevision)
+    }
   }))
 
   app.post('/commune/:codeCommune/validate', ensureCommuneActuelle, rawBodyParser(), validateBAL(), (req, res) => {


### PR DESCRIPTION
si les identifiants déclarés supprimés au préalable par la route PUT diff-bal ne sont pas identiques à ceux calculés automatiquement entre la révision et la révision courante on a un message  : 
"code": 400,
  "message": "les identifiants des adresses supprimées calculés et déclarés ne sont pas identiques."

Ceci empêche de poursuivre le compute, on ne peut continuer que si les identifiants sont identiques.
Retrocompatible avec des fichiers sans uid remplis.

fix #47 