### PR TITLE
Added docker & docker-compose files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,10 @@ dist
 # TernJS port file
 .tern-port
 
+# Docker files
+Dockerfile*
+docker-compose*
+
 /clients.yml
 /elus.json
 /admins.json


### PR DESCRIPTION
This pull request aims to ignore the docker & docker compose files that could be present in the repository to be able for a developper to work locally with it.