### PR TITLE
Ajout des informations publiques du client sur la récupération de la révision courante

### DIFF
--- a/lib/revisions/__tests__/integration.js
+++ b/lib/revisions/__tests__/integration.js
@@ -173,7 +173,9 @@ test.serial('basic revision', async t => {
     .expect(200)
 
   t.is(res6.body._id, revisionId)
+  t.truthy(res6.body.client._id)
   t.is(res6.body.client.id, 'id-client')
+  t.is(res6.body.client.nom, 'ACME')
 
   const res7 = await request(server)
     .get('/communes/31591/revisions')

--- a/lib/revisions/__tests__/integration.js
+++ b/lib/revisions/__tests__/integration.js
@@ -107,6 +107,7 @@ test.serial('basic revision', async t => {
 
   await mongo.db.collection('clients').insertOne({
     _id: new mongo.ObjectId(),
+    id: 'id-client',
     mandataire: mandataireId,
     nom: 'ACME',
     token: 'foobar',
@@ -172,6 +173,7 @@ test.serial('basic revision', async t => {
     .expect(200)
 
   t.is(res6.body._id, revisionId)
+  t.is(res6.body.client.id, 'id-client')
 
   const res7 = await request(server)
     .get('/communes/31591/revisions')

--- a/lib/revisions/routes.js
+++ b/lib/revisions/routes.js
@@ -36,7 +36,9 @@ async function revisionsRoutes() {
 
     const files = await getFiles(revision)
 
-    res.send({...revision, files})
+    const revisionWithPublicClient = await expandWithClient(revision)
+
+    res.send({...revisionWithPublicClient, files})
   }))
 
   async function sendBalFile(revision, res) {


### PR DESCRIPTION
## Contexte
Lors de la [migration des clients en BDD](https://github.com/BaseAdresseNationale/api-depot/pull/48), les informations publiques du client ont oublié d'être ajoutées à la réponse. 