### PR TITLE
Filtrer les révisions des communes déléguées des révisions courantes

### DIFF
--- a/lib/revisions/__tests__/model.js
+++ b/lib/revisions/__tests__/model.js
@@ -15,6 +15,10 @@ test.after.always('cleanup', async () => {
   await mongod.stop()
 })
 
+test.afterEach.always(async () => {
+  await mongo.db.collection('revisions').deleteMany({})
+})
+
 test('ensure habilitation / valid', async t => {
   const mandataireId = new mongo.ObjectId()
   await mongo.db.collection('mandataires').insertOne({
@@ -151,4 +155,27 @@ test('ensure habilitation / different client', async t => {
   }
 
   return t.throwsAsync(Revisions.getRelatedHabilitation(habilitationId, context), {message: 'L’habilitation fournie ne provient pas du même client'})
+})
+
+test.serial('getCurrentRevisions / commune actuelle', async t => {
+  await mongo.db.collection('revisions').insertOne({
+    _id: new mongo.ObjectId(),
+    codeCommune: '27115', // Breux-sur-Avre commune actuelle COG 2022
+    current: true
+  })
+
+  const currentRevisions = await Revisions.getCurrentRevisions()
+  t.is(currentRevisions.length, 1)
+  t.is(currentRevisions[0].codeCommune, '27115')
+})
+
+test.serial('getCurrentRevisions / commune déléguée', async t => {
+  await mongo.db.collection('revisions').insertOne({
+    _id: new mongo.ObjectId(),
+    codeCommune: '26219', // Mureils commune déléguée COG 2022
+    current: true
+  })
+
+  const currentRevisions = await Revisions.getCurrentRevisions()
+  t.is(currentRevisions.length, 0)
 })

--- a/lib/revisions/model.js
+++ b/lib/revisions/model.js
@@ -6,6 +6,7 @@ const mongo = require('../util/mongo')
 const Habilitation = require('../habilitations/model')
 const {composeCommune} = require('../util/api-ban')
 const Client = require('../clients/model')
+const {isCommuneActuelle} = require('../util/cog')
 const {applyValidateBAL} = require('./validate-bal')
 const {notifyPublication} = require('./slack')
 
@@ -201,13 +202,15 @@ function getRevisionsByCommune(codeCommune) {
   return mongo.db.collection('revisions').find({codeCommune, status: 'published'}).sort({publishedAt: 1}).toArray()
 }
 
-function getCurrentRevisions(publishedSince) {
+async function getCurrentRevisions(publishedSince) {
   const publishedSinceQuery = publishedSince ? {publishedAt: {$gt: publishedSince}} : {}
 
-  return mongo.db.collection('revisions')
+  const revisions = await mongo.db.collection('revisions')
     .find({current: true, ...publishedSinceQuery})
     .project({codeCommune: 1, publishedAt: 1, client: 1})
     .toArray()
+
+  return revisions.filter(r => isCommuneActuelle(r.codeCommune))
 }
 
 async function expandWithClient(revision) {


### PR DESCRIPTION
## Contexte
La route `/current-revisions` renvoi actuellement toutes les révisions courantes de toutes les communes. Cependant, lors de la mise à jour du COG, certaine commune deviennent des communes déléguées et leurs révisions ne doit plus être prise en compte.