### PR TITLE
Nouvelle fonctionnalité d'envoi d'email pour le token client

### DIFF
--- a/lib/clients/__tests__/model.js
+++ b/lib/clients/__tests__/model.js
@@ -156,6 +156,26 @@ test.serial('update client / extra param', async t => {
   t.deepEqual(chefDeFile._updatedAt, now)
 })
 
+test.serial('renew token', async t => {
+  const mandataireId = new mongo.ObjectId()
+  await mongo.db.collection('mandataires').insertOne({
+    _id: mandataireId,
+    email: 'mandataire@email.fr'
+  })
+
+  const _id = new mongo.ObjectId()
+  await mongo.db.collection('clients').insertOne({
+    _id,
+    mandataire: mandataireId,
+    token: '123456'
+  })
+
+  const client = await Client.renewToken(_id)
+
+  t.not(client.token, '123456')
+  t.is(client.token.length, 32)
+})
+
 test.serial('fetch client', async t => {
   const mandataireId = new mongo.ObjectId()
   await mongo.db.collection('mandataires').insertOne({_id: mandataireId, nom: 'mandataire'})

--- a/lib/clients/model.js
+++ b/lib/clients/model.js
@@ -3,6 +3,10 @@ const Joi = require('joi')
 const {pick, omit} = require('lodash')
 const mongo = require('../util/mongo')
 const {validObjectID, validPayload} = require('../util/payload')
+const {createNewClientEmail} = require('../emails/new-client-template')
+const {sendMail} = require('../util/sendmail')
+
+const DEMO_MODE = process.env.DEMO_MODE === '1'
 
 function generateToken() {
   const length = 32
@@ -28,8 +32,9 @@ const createSchema = Joi.object({
 async function create(payload) {
   const client = validPayload(payload, createSchema)
 
+  let chefDeFile
   if (client.chefDeFile) {
-    const chefDeFile = await mongo.db.collection('chefs_de_file').findOne({_id: client.chefDeFile})
+    chefDeFile = await mongo.db.collection('chefs_de_file').findOne({_id: client.chefDeFile})
     if (!chefDeFile) {
       throw createError(400, 'Chef de file introuvable')
     }
@@ -47,6 +52,10 @@ async function create(payload) {
   mongo.decorateCreation(client)
 
   await mongo.db.collection('clients').insertOne(client)
+
+  // Send token to user with mandataire’s email
+  const email = createNewClientEmail({client, mandataire, chefDeFile, isDemoMode: DEMO_MODE})
+  await sendMail(email, [mandataire.email])
 
   return client
 }

--- a/lib/clients/model.js
+++ b/lib/clients/model.js
@@ -3,7 +3,7 @@ const Joi = require('joi')
 const {pick, omit} = require('lodash')
 const mongo = require('../util/mongo')
 const {validObjectID, validPayload} = require('../util/payload')
-const {createNewClientEmail} = require('../emails/new-client-template')
+const createNewClientEmail = require('../emails/new-client-template')
 const {sendMail} = require('../util/sendmail')
 
 const DEMO_MODE = process.env.DEMO_MODE === '1'

--- a/lib/clients/model.js
+++ b/lib/clients/model.js
@@ -4,6 +4,7 @@ const {pick, omit} = require('lodash')
 const mongo = require('../util/mongo')
 const {validObjectID, validPayload} = require('../util/payload')
 const createNewClientEmail = require('../emails/new-client-template')
+const createTokenRenewalNotificationEmail = require('../emails/token-renewal-notification')
 const {sendMail} = require('../util/sendmail')
 
 const DEMO_MODE = process.env.DEMO_MODE === '1'
@@ -114,6 +115,31 @@ async function update(id, payload) {
   return value
 }
 
+async function renewToken(id) {
+  const {value} = await mongo.db.collection('clients').findOneAndUpdate(
+    {_id: mongo.parseObjectID(id)},
+    {$set: {token: generateToken(20)}},
+    {returnDocument: 'after'}
+  )
+
+  if (!value) {
+    throw new Error('Client introuvable')
+  }
+
+  const mandataire = await mongo.db.collection('mandataires').findOne({
+    _id: mongo.parseObjectID(value.mandataire)
+  })
+
+  if (!mandataire) {
+    throw new Error('Mandataire introuvable')
+  }
+
+  const email = createTokenRenewalNotificationEmail({client: value, isDemoMode: DEMO_MODE})
+  await sendMail(email, mandataire.email)
+
+  return value
+}
+
 function fetch(clientId) {
   try {
     clientId = new mongo.ObjectId(clientId)
@@ -165,6 +191,7 @@ function filterSensitiveFields(client) {
 module.exports = {
   create,
   update,
+  renewToken,
   fetch,
   fetchAll,
   computePublicClient,

--- a/lib/clients/routes.js
+++ b/lib/clients/routes.js
@@ -41,6 +41,11 @@ async function clientsRoutes() {
       res.status(201).send(client)
     }))
 
+  app.post('/clients/:clientId/token/renew', ensureIsAdmin, w(async (req, res) => {
+    const client = await Client.renewToken(req.client._id)
+    res.send(Client.filterSensitiveFields(client))
+  }))
+
   app.use(errorHandler)
 
   return app

--- a/lib/emails/__tests__/new-client-template.js
+++ b/lib/emails/__tests__/new-client-template.js
@@ -1,0 +1,289 @@
+const test = require('ava')
+const formatEmail = require('../new-client-template')
+
+test('new client email', t => {
+  const client = {token: '123456', nom: 'ACME CLI'}
+  const mandataire = {nom: 'ACME', email: 'acme@mail.fr'}
+  const chefDeFile = {nom: 'Warner', email: 'warner@mail.fr'}
+
+  const expectedTextBody = `
+  <!DOCTYPE html>
+  <html lang="fr">
+
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Demande de code d’identification</title>
+    <style>
+      body {
+        background-color: #F5F6F7;
+        color: #234361;
+        font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        margin: auto;
+        padding: 25px;
+      }
+
+      img {
+        max-height: 45px;
+        background-color: #F5F6F7;
+      }
+
+      .container {
+        background-color: #ebeff3;
+        padding: 25px;
+      }
+
+      .token {
+        font-weight: bold;
+      }
+
+      .title {
+        align-items: center;
+        border-bottom: 1px solid #E4E7EB;
+        justify-content: center;
+        margin-top: 35px;
+        min-height: 8em;
+        padding: 10px;
+        text-align: center;
+      }
+
+      .infos > div {
+          margin-top: 10px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div>
+      <img src="$$API_URL$$/public/images/logo-adresse.png" alt="Logo République Française">
+    </div>
+    <div class="title">
+      <h2 style="margin:0; mso-line-height-rule:exactly;">API dépôt</h2><br />
+      <h3 style="margin:0; mso-line-height-rule:exactly;">Accès autorisé</h3>
+    </div>
+
+    <div class="container">
+      <h5>Voici votre jeton :</h5>
+      <div class="token">123456</div>
+
+      <h5>URL de l’API :</5>
+      <div>$$API_URL$$</div>
+    </div>
+
+    <br />
+
+    <p>Résumé des informations que vous nous avez transmise</p>
+    <div class="infos">
+      <div>
+          <b>Solution technique</b>
+          <div>ACME CLI</div>
+      </div>
+
+      <div>
+          <b>Mandataire</b>
+          <div>nom : ACME</div>
+          <div>email : acme@mail.fr</div>
+      </div>
+
+      <div>
+          <b>Chef de file</b>
+          <div>nom : Warner</div>
+          <div>email : warner@mail.fr</div>
+      </div>
+    </div>
+
+    <p><i>L’équipe adresse.data.gouv.fr</i></p>
+  </body>
+  </html>
+`
+
+  t.is(formatEmail({client, mandataire, chefDeFile, isDemoMode: false}).html, expectedTextBody)
+})
+
+test('new client email / without chef de file', t => {
+  const client = {token: '123456', nom: 'ACME CLI'}
+  const mandataire = {nom: 'ACME', email: 'acme@mail.fr'}
+
+  const expectedTextBody = `
+  <!DOCTYPE html>
+  <html lang="fr">
+
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Demande de code d’identification</title>
+    <style>
+      body {
+        background-color: #F5F6F7;
+        color: #234361;
+        font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        margin: auto;
+        padding: 25px;
+      }
+
+      img {
+        max-height: 45px;
+        background-color: #F5F6F7;
+      }
+
+      .container {
+        background-color: #ebeff3;
+        padding: 25px;
+      }
+
+      .token {
+        font-weight: bold;
+      }
+
+      .title {
+        align-items: center;
+        border-bottom: 1px solid #E4E7EB;
+        justify-content: center;
+        margin-top: 35px;
+        min-height: 8em;
+        padding: 10px;
+        text-align: center;
+      }
+
+      .infos > div {
+          margin-top: 10px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div>
+      <img src="$$API_URL$$/public/images/logo-adresse.png" alt="Logo République Française">
+    </div>
+    <div class="title">
+      <h2 style="margin:0; mso-line-height-rule:exactly;">API dépôt</h2><br />
+      <h3 style="margin:0; mso-line-height-rule:exactly;">Accès autorisé</h3>
+    </div>
+
+    <div class="container">
+      <h5>Voici votre jeton :</h5>
+      <div class="token">123456</div>
+
+      <h5>URL de l’API :</5>
+      <div>$$API_URL$$</div>
+    </div>
+
+    <br />
+
+    <p>Résumé des informations que vous nous avez transmise</p>
+    <div class="infos">
+      <div>
+          <b>Solution technique</b>
+          <div>ACME CLI</div>
+      </div>
+
+      <div>
+          <b>Mandataire</b>
+          <div>nom : ACME</div>
+          <div>email : acme@mail.fr</div>
+      </div>
+
+      
+    </div>
+
+    <p><i>L’équipe adresse.data.gouv.fr</i></p>
+  </body>
+  </html>
+`
+
+  t.is(formatEmail({client, mandataire, isDemoMode: false}).html, expectedTextBody)
+})
+
+test('new client email / demo mode', t => {
+  const client = {token: '123456', nom: 'ACME CLI'}
+  const mandataire = {nom: 'ACME', email: 'acme@mail.fr'}
+
+  const expectedTextBody = `
+  <!DOCTYPE html>
+  <html lang="fr">
+
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Demande de code d’identification</title>
+    <style>
+      body {
+        background-color: #F5F6F7;
+        color: #234361;
+        font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        margin: auto;
+        padding: 25px;
+      }
+
+      img {
+        max-height: 45px;
+        background-color: #F5F6F7;
+      }
+
+      .container {
+        background-color: #ebeff3;
+        padding: 25px;
+      }
+
+      .token {
+        font-weight: bold;
+      }
+
+      .title {
+        align-items: center;
+        border-bottom: 1px solid #E4E7EB;
+        justify-content: center;
+        margin-top: 35px;
+        min-height: 8em;
+        padding: 10px;
+        text-align: center;
+      }
+
+      .infos > div {
+          margin-top: 10px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div>
+      <img src="$$API_URL$$/public/images/logo-adresse.png" alt="Logo République Française">
+    </div>
+    <div class="title">
+      <h2 style="margin:0; mso-line-height-rule:exactly;">API dépôt [DÉMONSTRATION]</h2><br />
+      <h3 style="margin:0; mso-line-height-rule:exactly;">Accès autorisé</h3>
+    </div>
+
+    <div class="container">
+      <h5>Voici votre jeton :</h5>
+      <div class="token">123456</div>
+
+      <h5>URL de l’API :</5>
+      <div>$$API_URL$$</div>
+    </div>
+
+    <br />
+
+    <p>Résumé des informations que vous nous avez transmise</p>
+    <div class="infos">
+      <div>
+          <b>Solution technique</b>
+          <div>ACME CLI</div>
+      </div>
+
+      <div>
+          <b>Mandataire</b>
+          <div>nom : ACME</div>
+          <div>email : acme@mail.fr</div>
+      </div>
+
+      
+    </div>
+
+    <p><i>L’équipe adresse.data.gouv.fr</i></p>
+  </body>
+  </html>
+`
+
+  t.is(formatEmail({client, mandataire, isDemoMode: true}).html, expectedTextBody)
+})

--- a/lib/emails/__tests__/token-renewal-notification.js
+++ b/lib/emails/__tests__/token-renewal-notification.js
@@ -1,0 +1,150 @@
+const test = require('ava')
+const formatEmail = require('../token-renewal-notification')
+
+test('token renewal notification', t => {
+  const client = {token: '123456'}
+
+  const expectedTextBody = `
+  <!DOCTYPE html>
+  <html lang="fr">
+
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Demande de code d’identification</title>
+    <style>
+      body {
+        background-color: #F5F6F7;
+        color: #234361;
+        font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        margin: auto;
+        padding: 25px;
+      }
+
+      img {
+        max-height: 45px;
+        background-color: #F5F6F7;
+      }
+
+      .container {
+        background-color: #ebeff3;
+        padding: 25px;
+      }
+
+      .token {
+        font-weight: bold;
+      }
+
+      .title {
+        align-items: center;
+        border-bottom: 1px solid #E4E7EB;
+        justify-content: center;
+        margin-top: 35px;
+        min-height: 8em;
+        padding: 10px;
+        text-align: center;
+      }
+
+      .infos > div {
+          margin-top: 10px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div>
+      <img src="$$API_URL$$/public/images/logo-adresse.png" alt="Logo République Française">
+    </div>
+    <div class="title">
+      <h2 style="margin:0; mso-line-height-rule:exactly;">API dépôt</h2><br />
+      <h3 style="margin:0; mso-line-height-rule:exactly;">Votre jeton vient d’être renouvelé</h3>
+    </div>
+
+    <div class="container">
+      <h5>Voici votre nouveau jeton :</h5>
+      <div class="token">123456</div>
+    </div>
+
+    <br />
+
+    <p><i>L’équipe adresse.data.gouv.fr</i></p>
+  </body>
+  </html>
+`
+
+  t.is(formatEmail({client, isDemoMode: false}).html, expectedTextBody)
+})
+
+test('new client email / demo mode', t => {
+  const client = {token: '123456'}
+
+  const expectedTextBody = `
+  <!DOCTYPE html>
+  <html lang="fr">
+
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Demande de code d’identification</title>
+    <style>
+      body {
+        background-color: #F5F6F7;
+        color: #234361;
+        font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        margin: auto;
+        padding: 25px;
+      }
+
+      img {
+        max-height: 45px;
+        background-color: #F5F6F7;
+      }
+
+      .container {
+        background-color: #ebeff3;
+        padding: 25px;
+      }
+
+      .token {
+        font-weight: bold;
+      }
+
+      .title {
+        align-items: center;
+        border-bottom: 1px solid #E4E7EB;
+        justify-content: center;
+        margin-top: 35px;
+        min-height: 8em;
+        padding: 10px;
+        text-align: center;
+      }
+
+      .infos > div {
+          margin-top: 10px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div>
+      <img src="$$API_URL$$/public/images/logo-adresse.png" alt="Logo République Française">
+    </div>
+    <div class="title">
+      <h2 style="margin:0; mso-line-height-rule:exactly;">API dépôt [DÉMONSTRATION]</h2><br />
+      <h3 style="margin:0; mso-line-height-rule:exactly;">Votre jeton vient d’être renouvelé</h3>
+    </div>
+
+    <div class="container">
+      <h5>Voici votre nouveau jeton :</h5>
+      <div class="token">123456</div>
+    </div>
+
+    <br />
+
+    <p><i>L’équipe adresse.data.gouv.fr</i></p>
+  </body>
+  </html>
+`
+
+  t.is(formatEmail({client, isDemoMode: true}).html, expectedTextBody)
+})

--- a/lib/emails/new-client-template.js
+++ b/lib/emails/new-client-template.js
@@ -1,0 +1,106 @@
+const {template} = require('lodash')
+
+const bodyTemplate = template(`
+  <!DOCTYPE html>
+  <html lang="fr">
+
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Demande de code d’identification</title>
+    <style>
+      body {
+        background-color: #F5F6F7;
+        color: #234361;
+        font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        margin: auto;
+        padding: 25px;
+      }
+
+      img {
+        max-height: 45px;
+        background-color: #F5F6F7;
+      }
+
+      .container {
+        background-color: #ebeff3;
+        padding: 25px;
+      }
+
+      .token {
+        font-weight: bold;
+      }
+
+      .title {
+        align-items: center;
+        border-bottom: 1px solid #E4E7EB;
+        justify-content: center;
+        margin-top: 35px;
+        min-height: 8em;
+        padding: 10px;
+        text-align: center;
+      }
+
+      .infos > div {
+          margin-top: 10px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div>
+      <img src="$$API_URL$$/public/images/logo-adresse.png" alt="Logo République Française">
+    </div>
+    <div class="title">
+      <h2 style="margin:0; mso-line-height-rule:exactly;">API dépôt<% if (isDemoMode) { %> [DÉMONSTRATION]<%}%></h2><br />
+      <h3 style="margin:0; mso-line-height-rule:exactly;">Accès autorisé</h3>
+    </div>
+
+    <div class="container">
+      <h5>Voici votre jeton :</h5>
+      <div class="token"><%= client.token %></div>
+
+      <h5>URL de l’API :</5>
+      <div>$$API_URL$$</div>
+    </div>
+
+    <br />
+
+    <p>Résumé des informations que vous nous avez transmise</p>
+    <div class="infos">
+      <div>
+          <b>Solution technique</b>
+          <div><%= client.nom %></div>
+      </div>
+
+      <div>
+          <b>Mandataire</b>
+          <div>nom : <%= mandataire.nom %></div>
+          <div>email : <%= mandataire.email %></div>
+      </div>
+
+      <% if (chefDeFile) { %><div>
+          <b>Chef de file</b>
+          <div>nom : <%= chefDeFile.nom %></div>
+          <div>email : <%= chefDeFile.email %></div>
+      </div><%}%>
+    </div>
+
+    <p><i>L’équipe adresse.data.gouv.fr</i></p>
+  </body>
+  </html>
+`)
+
+function formatEmail({client, mandataire, chefDeFile, isDemoMode}) {
+  return {
+    subject: 'Accès à l’API dépôt',
+    html: bodyTemplate({
+      client,
+      mandataire,
+      chefDeFile,
+      isDemoMode
+    })
+  }
+}
+
+module.exports = formatEmail

--- a/lib/emails/token-renewal-notification.js
+++ b/lib/emails/token-renewal-notification.js
@@ -1,0 +1,78 @@
+const {template} = require('lodash')
+
+const bodyTemplate = template(`
+  <!DOCTYPE html>
+  <html lang="fr">
+
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Demande de code d’identification</title>
+    <style>
+      body {
+        background-color: #F5F6F7;
+        color: #234361;
+        font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        margin: auto;
+        padding: 25px;
+      }
+
+      img {
+        max-height: 45px;
+        background-color: #F5F6F7;
+      }
+
+      .container {
+        background-color: #ebeff3;
+        padding: 25px;
+      }
+
+      .token {
+        font-weight: bold;
+      }
+
+      .title {
+        align-items: center;
+        border-bottom: 1px solid #E4E7EB;
+        justify-content: center;
+        margin-top: 35px;
+        min-height: 8em;
+        padding: 10px;
+        text-align: center;
+      }
+
+      .infos > div {
+          margin-top: 10px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div>
+      <img src="$$API_URL$$/public/images/logo-adresse.png" alt="Logo République Française">
+    </div>
+    <div class="title">
+      <h2 style="margin:0; mso-line-height-rule:exactly;">API dépôt<% if (isDemoMode) { %> [DÉMONSTRATION]<%}%></h2><br />
+      <h3 style="margin:0; mso-line-height-rule:exactly;">Votre jeton vient d’être renouvelé</h3>
+    </div>
+
+    <div class="container">
+      <h5>Voici votre nouveau jeton :</h5>
+      <div class="token"><%= client.token %></div>
+    </div>
+
+    <br />
+
+    <p><i>L’équipe adresse.data.gouv.fr</i></p>
+  </body>
+  </html>
+`)
+
+function formatEmail({client, isDemoMode}) {
+  return {
+    subject: 'Renouvellement de votre jeton',
+    html: bodyTemplate({client, isDemoMode})
+  }
+}
+
+module.exports = formatEmail


### PR DESCRIPTION
## Contexte
Le token des clients de l'API était précédemment créé par les administrateur et envoyé par email aux clients.
Depuis la [migration des clients en base de donnée](https://github.com/BaseAdresseNationale/api-depot/pull/48), ce token est généré par l'API. 

## Évolutions
Cette PR propose d'envoyer un email au mandataire du client avec son jeton, afin que même les administrateurs n'en ait pas connaissance.

De plus, une nouvelle `/clients/:clientId/token/renew` permet aux super admin de renouveler le token d'un client. Le nouveau token automatiquement envoyé au mandataire par email.

## Prévisualisation des emails
### Nouveau client
![Capture d’écran 2023-03-08 à 17 48 37](https://user-images.githubusercontent.com/7040549/223778824-f69105cc-cf55-44f6-86cc-5a56429295be.png)
### Renouvellement du jeton
![Capture d’écran 2023-03-08 à 17 48 27](https://user-images.githubusercontent.com/7040549/223778831-67ae2f7b-b980-4b7e-88a4-6ccca770ef1a.png)

## Autre modification
Le dossier `/public/images`, contenant le logo adresse.data.gouv.fr, a été ajouté au projet. Son chemin a été ajouté au serveur.

Cet ajout peut être considéré comme une correction, car cette image devait déjà être présente dans l'envoi du code secret d'identification des mairies.

-----

### Résumé
- l'envoi automatique du token client par email au mandataire
- une route `/clients/:clientId/token/renew` permettant au super admin de renouveler le token d'un client
- Ajout du dossier `/public/images` contenant le logo adresse.data.gouv.fr