### PR TITLE
Mise à jour COG 2023

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,13 @@
     "habilitations:build-rne": "node lib/habilitations/build-rne"
   },
   "dependencies": {
+<<<<<<< HEAD
     "@ban-team/validateur-bal": "^2.12.0",
     "@etalab/decoupage-administratif": "^2.0.0",
+=======
+    "@ban-team/validateur-bal": "^2.11.0",
+    "@etalab/decoupage-administratif": "^3.0.0",
+>>>>>>> 495ed15 (Update @etalab/decoupage-administratif v3.0.0)
     "@slack/web-api": "^6.7.0",
     "bytes": "^3.1.2",
     "connect-mongo": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -13,13 +13,8 @@
     "habilitations:build-rne": "node lib/habilitations/build-rne"
   },
   "dependencies": {
-<<<<<<< HEAD
-    "@ban-team/validateur-bal": "^2.12.0",
-    "@etalab/decoupage-administratif": "^2.0.0",
-=======
-    "@ban-team/validateur-bal": "^2.11.0",
+    "@ban-team/validateur-bal": "^2.13.0",
     "@etalab/decoupage-administratif": "^3.0.0",
->>>>>>> 495ed15 (Update @etalab/decoupage-administratif v3.0.0)
     "@slack/web-api": "^6.7.0",
     "bytes": "^3.1.2",
     "connect-mongo": "^4.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,10 +33,10 @@
   resolved "https://registry.yarnpkg.com/@ban-team/shared-data/-/shared-data-1.2.0.tgz#0e29e84a00f7df3b17e5821bde1405a2bfa656b5"
   integrity sha512-35jz6ITHHufUKxXAfa8ReSMl6lZarnfVBkS++wgHpk27e9K52bXyAHo+n3X331n2mSzoIQXxFK7SEcPob7a5cA==
 
-"@ban-team/validateur-bal@^2.12.0":
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/@ban-team/validateur-bal/-/validateur-bal-2.12.0.tgz#4d8eb83291cfdfc1cdfa574b36cc9f7ca716bd0f"
-  integrity sha512-+bI65V10UVfJUrKQIH9+R4LfygcWPNz/n08Z6ThDhkX7eWfesgHMJlimIqpKRavrwjaowFtGrHgWaW/qP06rSA==
+"@ban-team/validateur-bal@^2.13.0":
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/@ban-team/validateur-bal/-/validateur-bal-2.13.0.tgz#0d23e8192f631614d59312d265a04697f8fe09db"
+  integrity sha512-+GFoSti7n5dn4l+ZjiWjk19wkdxauhDIFa0gk3uIsDInwE1e3HiCdYxDYkYMAeU5/p1XadxANIVv73CH92YGbg==
   dependencies:
     "@ban-team/shared-data" "^1.2.0"
     "@etalab/project-legal" "^0.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -66,10 +66,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@etalab/decoupage-administratif@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@etalab/decoupage-administratif/-/decoupage-administratif-2.0.0.tgz#24ee640070c47e3c62883873c35450197fa5f78c"
-  integrity sha512-X+pQDnm0Sk8T5KPhT5kU9cLyMKc+LagK8ObYxyzVDoQapjLNZl9/KY2VFr42aw4LEiTnUfqCgNZc9lhHfi6shQ==
+"@etalab/decoupage-administratif@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@etalab/decoupage-administratif/-/decoupage-administratif-3.0.0.tgz#1d0d54b5b884c3df9555b4b8db543f83559629d3"
+  integrity sha512-WlXHeArXK7zwcxoPev8NM3ncUjaIiBYiTmY1wh3X6RXITKjTwn3yaYdQqbPplTfFA/ByllG4Y4q4Jt0bCmbEzw==
 
 "@etalab/project-legal@^0.6.0":
   version "0.6.0"


### PR DESCRIPTION
## Contexte
Mise à jour de `@etalab/decoupage-administratif v3.0.0` pour la mise à jour du COG 2023.