### PR TITLE
Nouvelle routes de stats pour dashboard BalAdmin

### DIFF
--- a/lib/revisions/__tests__/model.js
+++ b/lib/revisions/__tests__/model.js
@@ -1,4 +1,5 @@
 const test = require('ava')
+const {sub} = require('date-fns')
 const {MongoMemoryServer} = require('mongodb-memory-server')
 const mongo = require('../../util/mongo')
 const Revisions = require('../model')
@@ -178,4 +179,66 @@ test.serial('getCurrentRevisions / commune déléguée', async t => {
 
   const currentRevisions = await Revisions.getCurrentRevisions()
   t.is(currentRevisions.length, 0)
+})
+
+test.serial('getRevisionsPublishedBetweenDate', async t => {
+  const revisions = [
+    {
+      _id: new mongo.ObjectId(),
+      publishedAt: sub(new Date(), {days: 2})
+    },
+    {
+      _id: new mongo.ObjectId(),
+      publishedAt: sub(new Date(), {days: 5})
+    },
+    {
+      _id: new mongo.ObjectId(),
+      publishedAt: sub(new Date(), {days: 10})
+    },
+    {
+      _id: new mongo.ObjectId(),
+      publishedAt: null
+    }
+  ]
+  await mongo.db.collection('revisions').insertMany(revisions)
+  const res0 = await Revisions.getRevisionsPublishedBetweenDate({from: sub(new Date(), {days: 1}), to: new Date()})
+  t.is(res0.length, 0)
+  const res1 = await Revisions.getRevisionsPublishedBetweenDate({from: sub(new Date(), {days: 3}), to: new Date()})
+  t.is(res1.length, 1)
+  const res2 = await Revisions.getRevisionsPublishedBetweenDate({from: sub(new Date(), {days: 6}), to: new Date()})
+  t.is(res2.length, 2)
+  const res3 = await Revisions.getRevisionsPublishedBetweenDate({from: sub(new Date(), {days: 11}), to: new Date()})
+  t.is(res3.length, 3)
+})
+
+test.serial('getFirstRevisionsPublishedByCommune', async t => {
+  const revisions = [
+    {
+      _id: new mongo.ObjectId(),
+      codeCommune: '00000',
+      publishedAt: sub(new Date(), {days: 2})
+    },
+    {
+      _id: new mongo.ObjectId(),
+      codeCommune: '00000',
+      publishedAt: sub(new Date(), {days: 5})
+    },
+    {
+      _id: new mongo.ObjectId(),
+      codeCommune: '00000',
+      publishedAt: sub(new Date(), {days: 10})
+    },
+    {
+      _id: new mongo.ObjectId(),
+      codeCommune: '00001',
+      publishedAt: sub(new Date(), {days: 1})
+    },
+    {
+      _id: new mongo.ObjectId(),
+      codeCommune: '00002'
+    }
+  ]
+  await mongo.db.collection('revisions').insertMany(revisions)
+  const res = await Revisions.getFirstRevisionsPublishedByCommune()
+  t.is(res.length, 2)
 })

--- a/lib/revisions/model.js
+++ b/lib/revisions/model.js
@@ -228,6 +228,35 @@ async function expandWithClient(revision) {
   return {...revision, client: publicClient}
 }
 
+async function getRevisionsPublishedBetweenDate(dates) {
+  return mongo.db.collection('revisions').find(
+    {
+      publishedAt: {
+        $gte: dates.from,
+        $lte: dates.to
+      }
+    }
+  ).toArray()
+}
+
+async function getFirstRevisionsPublishedByCommune() {
+  return mongo.db.collection('revisions').aggregate([
+    {
+      $match: {
+        publishedAt: {
+          $ne: null
+        }
+      }
+    },
+    {
+      $group: {
+        _id: {codeCommune: '$codeCommune'},
+        publishedAt: {$first: '$publishedAt'}
+      }
+    }
+  ]).toArray()
+}
+
 module.exports = {
   createRevision,
   setFile,
@@ -240,5 +269,7 @@ module.exports = {
   computeRevision,
   getCurrentRevisions,
   getRelatedHabilitation,
-  expandWithClient
+  expandWithClient,
+  getRevisionsPublishedBetweenDate,
+  getFirstRevisionsPublishedByCommune
 }

--- a/lib/stats/__tests__/routes.js
+++ b/lib/stats/__tests__/routes.js
@@ -1,0 +1,39 @@
+const test = require('ava')
+const {checkQueryDateFromTo} = require('../routes')
+
+test('checkDateFromTo lake to', async t => {
+  const error = await t.throws(() =>
+    checkQueryDateFromTo({query: {from: '2022-06-06'}})
+  )
+  t.is(error.message, 'Il manque une date from ou to')
+})
+
+test('checkDateFromTo lake from', async t => {
+  const error = await t.throws(() =>
+    checkQueryDateFromTo({query: {to: '2022-06-06'}})
+  )
+  t.is(error.message, 'Il manque une date from ou to')
+})
+
+test('checkDateFromTo bad to', async t => {
+  const error = await t.throws(() =>
+    checkQueryDateFromTo({query: {to: 'xxxx', from: '2022-06-06'}})
+  )
+  t.is(error.message, 'Les dates ne sont pas valides')
+})
+
+test('checkDateFromTo bad from', async t => {
+  const error = await t.throws(() =>
+    checkQueryDateFromTo({query: {to: '2022-06-06', from: 'xxxx'}})
+  )
+  t.is(error.message, 'Les dates ne sont pas valides')
+})
+
+test('checkDateFromTo from after to', async t => {
+  const error = await t.throws(() =>
+    checkQueryDateFromTo({query:
+      {from: '2022-06-07', to: '2022-06-06'}
+    })
+  )
+  t.is(error.message, 'La date from est plus vielle que la date to')
+})

--- a/lib/stats/__tests__/service.js
+++ b/lib/stats/__tests__/service.js
@@ -1,0 +1,62 @@
+const test = require('ava')
+const {sub, format} = require('date-fns')
+const StatsService = require('../service')
+
+test('getCumulFirstRevisionsByDate', t => {
+  const revisions = [
+    {publishedAt: sub(new Date(), {days: 1})},
+    {publishedAt: sub(new Date(), {days: 2})},
+    {publishedAt: sub(new Date(), {days: 3})},
+    {publishedAt: sub(new Date(), {days: 4})},
+    {publishedAt: sub(new Date(), {days: 5})},
+    {publishedAt: sub(new Date(), {days: 6})}
+  ]
+  const res = StatsService.getCumulFirstRevisionsByDate(revisions, {from: sub(new Date(), {days: 7}), to: new Date()})
+  const resExpected = [
+    {date: format(sub(new Date(), {days: 7}), 'yyyy-MM-dd'), totalCreations: 0},
+    {date: format(sub(new Date(), {days: 6}), 'yyyy-MM-dd'), totalCreations: 0},
+    {date: format(sub(new Date(), {days: 5}), 'yyyy-MM-dd'), totalCreations: 1},
+    {date: format(sub(new Date(), {days: 4}), 'yyyy-MM-dd'), totalCreations: 2},
+    {date: format(sub(new Date(), {days: 3}), 'yyyy-MM-dd'), totalCreations: 3},
+    {date: format(sub(new Date(), {days: 2}), 'yyyy-MM-dd'), totalCreations: 4},
+    {date: format(sub(new Date(), {days: 1}), 'yyyy-MM-dd'), totalCreations: 5},
+    {date: format(sub(new Date(), {days: 0}), 'yyyy-MM-dd'), totalCreations: 6}
+  ]
+  t.is(res.length, 8)
+  t.deepEqual(res, resExpected)
+})
+
+test('getBalsByDays', t => {
+  const revisions = [
+    {publishedAt: sub(new Date(), {days: 2}), codeCommune: '00000'},
+    {publishedAt: sub(new Date(), {days: 2}), codeCommune: '00000'},
+    {publishedAt: sub(new Date(), {days: 2}), codeCommune: '00000'},
+    {publishedAt: sub(new Date(), {days: 2}), codeCommune: '00001'},
+    {publishedAt: sub(new Date(), {days: 5}), codeCommune: '00001'},
+    {publishedAt: sub(new Date(), {days: 6}), codeCommune: '00001'}
+  ]
+  const res = StatsService.getBalsByDays(revisions)
+  const resExpected = [
+    {
+      date: format(sub(new Date(), {days: 2}), 'yyyy-MM-dd'),
+      publishedBAL: [
+        {codeCommune: '00000', numPublications: 3},
+        {codeCommune: '00001', numPublications: 1}
+      ]
+    },
+    {
+      date: format(sub(new Date(), {days: 5}), 'yyyy-MM-dd'),
+      publishedBAL: [
+        {codeCommune: '00001', numPublications: 1}
+      ]
+    },
+    {
+      date: format(sub(new Date(), {days: 6}), 'yyyy-MM-dd'),
+      publishedBAL: [
+        {codeCommune: '00001', numPublications: 1}
+      ]
+    }
+  ]
+  t.deepEqual(res, resExpected)
+})
+

--- a/lib/stats/routes.js
+++ b/lib/stats/routes.js
@@ -1,0 +1,61 @@
+const express = require('express')
+const createError = require('http-errors')
+const {sub} = require('date-fns')
+const errorHandler = require('../util/error-handler')
+const w = require('../util/w')
+const Revisions = require('../revisions/model')
+const {ensureIsAdmin} = require('../util/middlewares')
+const {checkFromIsBeforeTo, isValidDate} = require('../util/date')
+const StatsService = require('./service')
+
+function checkQueryDateFromTo(req) {
+  if ((req.query.from && !req.query.to) || (!req.query.from && req.query.to)) {
+    throw createError(400, 'Il manque une date from ou to')
+  }
+
+  if (req.query.from && req.query.to) {
+    if (!isValidDate(req.query.from) || !isValidDate(req.query.to)) {
+      throw createError(400, 'Les dates ne sont pas valides')
+    }
+
+    if (!checkFromIsBeforeTo(req.query.from, req.query.to)) {
+      throw createError(400, 'La date from est plus vielle que la date to')
+    }
+  }
+}
+
+async function statsRoutes() {
+  const app = new express.Router()
+
+  app.use(express.json())
+
+  app.get('/stats/firsts-publications', ensureIsAdmin, w(async (req, res) => {
+    checkQueryDateFromTo(req)
+    const dates = {
+      from: req.query.from ? new Date(req.query.from) : sub(new Date(), {months: 1}),
+      to: req.query.to ? new Date(req.query.to) : new Date()
+    }
+
+    const firstRevisions = await Revisions.getFirstRevisionsPublishedByCommune()
+    const cumulFirstRevisionsByDate = StatsService.getCumulFirstRevisionsByDate(firstRevisions, dates)
+    res.send(cumulFirstRevisionsByDate)
+  }))
+
+  app.get('/stats/publications', ensureIsAdmin, w(async (req, res) => {
+    checkQueryDateFromTo(req)
+    const dates = {
+      from: req.query.from ? new Date(req.query.from) : sub(new Date(), {months: 1}),
+      to: req.query.to ? new Date(req.query.to) : new Date()
+    }
+
+    const revisions = await Revisions.getRevisionsPublishedBetweenDate(dates)
+    const balsByDays = StatsService.getBalsByDays(revisions)
+    res.send(balsByDays)
+  }))
+
+  app.use(errorHandler)
+
+  return app
+}
+
+module.exports = {statsRoutes, checkQueryDateFromTo}

--- a/lib/stats/service.js
+++ b/lib/stats/service.js
@@ -1,0 +1,43 @@
+const {groupBy} = require('lodash')
+const {format, compareDesc, add, startOfDay} = require('date-fns')
+
+function getCumulFirstRevisionsByDate(firstRevisions, dates) {
+  const cumulFirstRevisionsByDate = []
+  for (
+    let dateIterator = startOfDay(new Date(dates.from.getTime()));
+    compareDesc(dateIterator, dates.to) > 0;
+    dateIterator = add(dateIterator, {days: 1})
+  ) {
+    cumulFirstRevisionsByDate.push({
+      date: format(dateIterator, 'yyyy-MM-dd'),
+      totalCreations: firstRevisions.filter(firstRevision => compareDesc(firstRevision.publishedAt, dateIterator) === 1).length
+    })
+  }
+
+  return cumulFirstRevisionsByDate
+}
+
+function getBalsByDays(revisions) {
+  const revisionsGroupByDays = groupBy(revisions, revision =>
+    format(revision.publishedAt, 'yyyy-MM-dd')
+  )
+  return Object.entries(revisionsGroupByDays).map(([date, revisions]) => {
+    const revisionsGroupByBals = groupBy(revisions, revision =>
+      revision.codeCommune
+    )
+    const publishedBAL = Object.entries(revisionsGroupByBals).map(([codeCommune, revisionsByBal]) => ({
+      codeCommune,
+      numPublications: revisionsByBal.length
+    }))
+
+    return {
+      date,
+      publishedBAL
+    }
+  })
+}
+
+module.exports = {
+  getBalsByDays,
+  getCumulFirstRevisionsByDate
+}

--- a/lib/util/__tests__/date.js
+++ b/lib/util/__tests__/date.js
@@ -1,0 +1,22 @@
+const test = require('ava')
+const DateUtil = require('../date')
+
+test('isValidDate invalid', t => {
+  const res = DateUtil.isValidDate('xxxxx')
+  t.is(res, false)
+})
+
+test('isValidDate valid', t => {
+  const res = DateUtil.isValidDate('2022-06-08')
+  t.is(res, true)
+})
+
+test('checkFromIsBeforeTo invalid', t => {
+  const res = DateUtil.checkFromIsBeforeTo('2022-06-08', '2022-06-07')
+  t.is(res, false)
+})
+
+test('checkFromIsBeforeTo valid', t => {
+  const res = DateUtil.checkFromIsBeforeTo('2022-06-06', '2022-06-07')
+  t.is(res, true)
+})

--- a/lib/util/date.js
+++ b/lib/util/date.js
@@ -1,0 +1,14 @@
+const {compareDesc, parse, isValid} = require('date-fns')
+
+function isValidDate(date) {
+  const dateObj = parse(date, 'yyyy-MM-dd', new Date())
+  return isValid(dateObj)
+}
+
+function checkFromIsBeforeTo(from, to) {
+  const dateFrom = new Date(from)
+  const dateTo = new Date(to)
+  return compareDesc(dateFrom, dateTo) >= 0
+}
+
+module.exports = {isValidDate, checkFromIsBeforeTo}

--- a/server.js
+++ b/server.js
@@ -10,6 +10,7 @@ const {habilitationsRoutes} = require('./lib/habilitations/routes')
 const {clientsRoutes} = require('./lib/clients/routes')
 const {mandatairesRoutes} = require('./lib/mandataires/routes')
 const {chefsDeFileRoutes} = require('./lib/chefs-de-file/routes')
+const {statsRoutes} = require('./lib/stats/routes')
 
 async function main() {
   const app = express()
@@ -30,12 +31,14 @@ async function main() {
   const clients = await clientsRoutes()
   const mandataires = await mandatairesRoutes()
   const chefsDeFile = await chefsDeFileRoutes()
+  const stats = await statsRoutes()
 
   app.use('/', revisions)
   app.use('/', habilitation)
   app.use('/', clients)
   app.use('/', mandataires)
   app.use('/', chefsDeFile)
+  app.use('/', stats)
 
   app.listen(port, () => {
     console.log(`Start listening on port ${port}`)


### PR DESCRIPTION
## Context

BalAdmin a besoin d'afficher des stats sur la home, il y a donc besoin d'ajouter des routes sur l'api-depot

## Fonctionnalité

Route `stats/creation-evolution?from&to`
Description: Retourne le nombre cumulé de première révision de BAL publiée pour chaque jours entre 'from' et 'to' inclus
    Query : `stats/creation-evolution?from=2023-03-12&to=2023-03-28`
    Réponse : 
```JSON
[
 { 
    "date": "2023-03-12",
    "totalCreations": 1000
 },
 {
    "date": "2023-03-28",
    "totalCreations": 1010
 }
]
```


Route `stats/publications?from&to`
Description: Retourne les BAL publiées pour chaque jours entre 'from' et 'to' inclus
    Query : 
      `stats/publications?from=2023-03-12&to=2023-03-28`
    Réponse : 
```JSON
[
  { 
    "date": "2023-03-12",
    "publishedBAL": [
      { 
        "codeCommune": "37003",
        "numPublications": 3
      }
    ]
  }
]
```

