### PR TITLE
Correction des performances de la route /current-revisions

### DIFF
--- a/lib/revisions/model.js
+++ b/lib/revisions/model.js
@@ -1,6 +1,6 @@
 const process = require('process')
 const hasha = require('hasha')
-const {omit, pick} = require('lodash')
+const {omit, pick, keyBy} = require('lodash')
 const createError = require('http-errors')
 const mongo = require('../util/mongo')
 const Habilitation = require('../habilitations/model')
@@ -228,6 +228,17 @@ async function expandWithClient(revision) {
   return {...revision, client: publicClient}
 }
 
+async function expandWithClients(revisions) {
+  const clients = await mongo.db.collection('clients').find({_id: {$in: revisions.map(r => r.client)}}).toArray()
+  const publicClients = await Promise.all(clients.map(client => Client.computePublicClient(client._id)))
+  const clientsById = keyBy(publicClients, '_id')
+
+  return revisions.map(r => ({
+    ...r,
+    client: clientsById[r.client.toString()]
+  }))
+}
+
 async function getRevisionsPublishedBetweenDate(dates) {
   return mongo.db.collection('revisions').find(
     {
@@ -270,6 +281,7 @@ module.exports = {
   getCurrentRevisions,
   getRelatedHabilitation,
   expandWithClient,
+  expandWithClients,
   getRevisionsPublishedBetweenDate,
   getFirstRevisionsPublishedByCommune
 }

--- a/lib/revisions/routes.js
+++ b/lib/revisions/routes.js
@@ -6,7 +6,7 @@ const {authClient, ensureCodeCommune, ensureCommuneActuelle, authRevision} = req
 const w = require('../util/w')
 const rawBodyParser = require('../util/raw-body-parser')
 const {validateBAL} = require('./validate-bal')
-const {fetchRevision, getCurrentRevision, getRevisionsByCommune, createRevision, setFile, getFiles, getFileData, publishRevision, computeRevision, getCurrentRevisions, getRelatedHabilitation, expandWithClient} = require('./model')
+const {fetchRevision, getCurrentRevision, getRevisionsByCommune, createRevision, setFile, getFiles, getFileData, publishRevision, computeRevision, getCurrentRevisions, getRelatedHabilitation, expandWithClient, expandWithClients} = require('./model')
 
 async function revisionsRoutes() {
   const app = new express.Router()
@@ -176,7 +176,7 @@ async function revisionsRoutes() {
       : undefined
 
     const currentRevisions = await getCurrentRevisions(publishedSince)
-    const currentRevisionsWithPublicClients = await Promise.all(currentRevisions.map(r => expandWithClient(r)))
+    const currentRevisionsWithPublicClients = await expandWithClients(currentRevisions)
 
     res.send(currentRevisionsWithPublicClients)
   }))


### PR DESCRIPTION
## Contexte
Des problèmes de performance ont été constatés sur la `/current-revisions` depuis la migration des clients de dépôt. 
C'est dû à traitement des clients des révisions très peu optimisé.

## Correction
Cette PR ajoute la méthode `expandWithClients` qui permet de traiter tous les clients en même temps plutôt de gérer les clients révision par révision.