### PR TITLE
Mise à jour des URL vers plateforme-bal

### DIFF
--- a/lib/habilitations/model.js
+++ b/lib/habilitations/model.js
@@ -4,7 +4,7 @@ const createError = require('http-errors')
 const mongo = require('../util/mongo')
 const Client = require('../clients/model')
 
-const API_ETABLISSEMENTS_PUBLICS = process.env.API_ETABLISSEMENTS_PUBLICS || 'https://plateforme.adresse.data.gouv.fr/api-annuaire/v3'
+const API_ETABLISSEMENTS_PUBLICS = process.env.API_ETABLISSEMENTS_PUBLICS || 'https://plateforme-bal.adresse.data.gouv.fr/api-annuaire/v3'
 
 async function getCommuneEmail(codeCommune) {
   try {

--- a/lib/util/sendmail.js
+++ b/lib/util/sendmail.js
@@ -10,7 +10,7 @@ function getApiUrl() {
     throw new Error('API_DEPOT_URL must be defined in production mode')
   }
 
-  return 'https://plateforme.adresse.data.gouv.fr.local'
+  return 'https://plateforme-bal.adresse.data.gouv.fr.local'
 }
 
 module.exports = {getApiUrl}


### PR DESCRIPTION
## Contexte

Les appels vers les briques BAL sont aujourd'hui redirigés de https://plateforme.adresse.data.gouv.fr/ vers https://plateforme-bal.adresse.data.gouv.fr/.

## Évolution

Cette PR met à jour les variables d'environnement et les URL de fallback pour pointer directement vers la nouvelle URL https://plateforme-bal.adresse.data.gouv.fr/