### PR TITLE
Email bien replace le tag Url Api

### DIFF
--- a/lib/util/sendmail.js
+++ b/lib/util/sendmail.js
@@ -47,8 +47,7 @@ async function sendMail(email, recipients = []) {
   }
 
   const apiUrl = getApiUrl()
-  email.html.replace(/\$\$API_URL\$\$/g, apiUrl)
-
+  email.html = email.html.replace(/\$\$API_URL\$\$/g, apiUrl)
   const info = await transport.sendMail({
     ...pick(email, 'text', 'html', 'subject'),
     from: process.env.SMTP_FROM,


### PR DESCRIPTION
## Context

Le tag `$$API_URL$$` n'était pas remplacer lors de la création du template pour les mail de l'api-depot.

## Fonctionnalité

Utiliser la fonctionnalité template de lodash pour remplacer les nouveau tag `apiUrl` par la var env `API_DEPOT_URL`