### PR TITLE
Delete filterSensitiveFields to route /clients/:clientId

### DIFF
--- a/lib/clients/routes.js
+++ b/lib/clients/routes.js
@@ -24,7 +24,7 @@ async function clientsRoutes() {
 
   app.route('/clients/:clientId')
     .get(ensureIsAdmin, w(async (req, res) => {
-      res.send(Client.filterSensitiveFields(req.client))
+      res.send(req.client)
     }))
     .put(ensureIsAdmin, w(async (req, res) => {
       const client = await Client.update(req.client._id, req.body)


### PR DESCRIPTION
## Context

https://github.com/BaseAdresseNationale/bal-admin/issues/18

## Fonctionnalité

Ne plus omettre le champ `token` d'un client sur la route `client/:clientId`