### PR TITLE
Bloquer publish bal 0 line

### DIFF
--- a/lib/revisions/validate-bal.js
+++ b/lib/revisions/validate-bal.js
@@ -54,6 +54,10 @@ async function applyValidateBAL(file, codeCommune, options = {}) {
     }
   }
 
+  if (rows.length <= 0) {
+    throw createError(400, 'Le fichier BAL analysé ne comporte aucune lignes de données.')
+  }
+
   if (rowsCountValue && Number.parseInt(rowsCountValue, 10) !== rows.length) {
     throw createError(400, 'Le fichier BAL analysé ne comporte pas le nombre de lignes de données indiqué dans l’en-tête X-Rows-Count.')
   }


### PR DESCRIPTION
## Context

https://github.com/BaseAdresseNationale/api-depot/issues/89

## Fonctionnalité

Empêcher les fichiers BAL qui ne comporte aucune lignes d'être publier