### PR TITLE
fix: change API annuaire url to public instance

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,7 +1,7 @@
 MONGODB_URL=mongodb://localhost
 MONGODB_DBNAME=api-depot
 API_DEPOT_URL=https://plateforme-bal.adresse.data.gouv.fr/api-depot
-API_ETABLISSEMENTS_PUBLICS=https://plateforme-bal.adresse.data.gouv.fr/api-annuaire/v3
+API_ETABLISSEMENTS_PUBLICS=https://etablissements-publics.api.gouv.fr/v3
 SMTP_HOST=
 SMTP_PORT=
 SMTP_SECURE=YES

--- a/lib/habilitations/model.js
+++ b/lib/habilitations/model.js
@@ -4,7 +4,7 @@ const createError = require('http-errors')
 const mongo = require('../util/mongo')
 const Client = require('../clients/model')
 
-const API_ETABLISSEMENTS_PUBLICS = process.env.API_ETABLISSEMENTS_PUBLICS || 'https://plateforme-bal.adresse.data.gouv.fr/api-annuaire/v3'
+const API_ETABLISSEMENTS_PUBLICS = process.env.API_ETABLISSEMENTS_PUBLICS || 'https://etablissements-publics.api.gouv.fr/v3'
 
 async function getCommuneEmail(codeCommune) {
   try {


### PR DESCRIPTION
Migration vers l'API annuaire public.

Penser à changer le .env sur bal-1 au déploiement