### PR TITLE
Route all revisions by commune

### DIFF
--- a/lib/revisions/__tests__/model.js
+++ b/lib/revisions/__tests__/model.js
@@ -457,3 +457,81 @@ test.serial('getFileData - should fallback to DB storage if file integrity check
   const res = await Revisions.getFileData(fileId)
   t.is(res.length, 793)
 })
+
+test.serial('getRevisionsByCommune / all', async t => {
+  const codeCommune = '00000'
+
+  const revisions = [
+    {
+      _id: new mongo.ObjectId(),
+      codeCommune,
+      status: 'published'
+    },
+    {
+      _id: new mongo.ObjectId(),
+      codeCommune,
+      status: 'pending'
+    },
+    {
+      _id: new mongo.ObjectId(),
+      codeCommune: '10000',
+      status: 'published'
+    }
+  ]
+
+  await mongo.db.collection('revisions').insertMany(revisions)
+  const res = await Revisions.getRevisionsByCommune(codeCommune, 'all')
+  t.is(res.length, 2)
+})
+
+test.serial('getRevisionsByCommune / default', async t => {
+  const codeCommune = '00000'
+
+  const revisions = [
+    {
+      _id: new mongo.ObjectId(),
+      codeCommune,
+      status: 'published'
+    },
+    {
+      _id: new mongo.ObjectId(),
+      codeCommune,
+      status: 'pending'
+    },
+    {
+      _id: new mongo.ObjectId(),
+      codeCommune: '10000',
+      status: 'published'
+    }
+  ]
+
+  await mongo.db.collection('revisions').insertMany(revisions)
+  const res = await Revisions.getRevisionsByCommune(codeCommune, 'published')
+  t.is(res.length, 1)
+})
+
+test.serial('getRevisionsByCommune / pending', async t => {
+  const codeCommune = '00000'
+
+  const revisions = [
+    {
+      _id: new mongo.ObjectId(),
+      codeCommune,
+      status: 'published'
+    },
+    {
+      _id: new mongo.ObjectId(),
+      codeCommune,
+      status: 'pending'
+    },
+    {
+      _id: new mongo.ObjectId(),
+      codeCommune: '10000',
+      status: 'published'
+    }
+  ]
+
+  await mongo.db.collection('revisions').insertMany(revisions)
+  const res = await Revisions.getRevisionsByCommune(codeCommune, 'pending')
+  t.is(res.length, 1)
+})

--- a/lib/revisions/model.js
+++ b/lib/revisions/model.js
@@ -242,8 +242,22 @@ function getCurrentRevision(codeCommune) {
   return mongo.db.collection('revisions').findOne({codeCommune, current: true})
 }
 
-function getRevisionsByCommune(codeCommune) {
-  return mongo.db.collection('revisions').find({codeCommune, status: 'published'}).sort({publishedAt: 1}).toArray()
+function getRevisionsByCommune(codeCommune, status) {
+  const filters = {
+    codeCommune,
+    status: 'published'
+  }
+
+  if (status === 'all') {
+    delete filters.status
+  } else if (status === 'pending') {
+    filters.status = 'pending'
+  }
+
+  return mongo.db.collection('revisions')
+    .find({...filters})
+    .sort({publishedAt: 1})
+    .toArray()
 }
 
 async function getCurrentRevisions(publishedSince) {

--- a/lib/revisions/routes.js
+++ b/lib/revisions/routes.js
@@ -68,7 +68,8 @@ async function revisionsRoutes() {
   }))
 
   app.get('/communes/:codeCommune/revisions', w(async (req, res) => {
-    const revisions = await Revision.getRevisionsByCommune(req.codeCommune)
+    const status = req.query.status
+    const revisions = await Revision.getRevisionsByCommune(req.codeCommune, status)
     const revisionsWithPublicClients = await Promise.all(revisions.map(r => Revision.expandWithClient(r)))
 
     res.send(revisionsWithPublicClients)


### PR DESCRIPTION
## Context

La route `communes/:codeCommune/revisions` ne renvoie que les revisions published

## Fonctionnalité

Nouvelle Route `communes/:codeCommune/revisions/all` qui renvoie toutes revisions d'une commune