### PR TITLE
route admin delete current revision

### DIFF
--- a/lib/revisions/__tests__/model.js
+++ b/lib/revisions/__tests__/model.js
@@ -378,3 +378,29 @@ test.serial('computeRevision with relax mode false', async t => {
   t.is(validation.valid, false)
   t.not(validation.errors.length, 0)
 })
+
+test.serial('getAllRevisionsByCommune / valid', async t => {
+  const codeCommune = '00000'
+
+  const revisions = [
+    {
+      _id: new mongo.ObjectId(),
+      codeCommune,
+      status: 'published'
+    },
+    {
+      _id: new mongo.ObjectId(),
+      codeCommune,
+      status: 'pending'
+    },
+    {
+      _id: new mongo.ObjectId(),
+      codeCommune: '10000',
+      status: 'published'
+    }
+  ]
+
+  await mongo.db.collection('revisions').insertMany(revisions)
+  const res = await Revisions.getAllRevisionsByCommune(codeCommune)
+  t.is(res.length, 2)
+})

--- a/lib/revisions/__tests__/routes.js
+++ b/lib/revisions/__tests__/routes.js
@@ -1,3 +1,7 @@
+require('dotenv').config()
+
+process.env.ADMIN_TOKEN = 'xxxxxxxxxxxxxxx'
+
 const test = require('ava')
 const express = require('express')
 const request = require('supertest')
@@ -207,4 +211,177 @@ test.serial('publish revision / consecutive', async t => {
   t.is(resB.body.status, 'published')
   t.is(resB.body.current, true)
   t.truthy(resB.body.habilitation)
+})
+
+test.serial('Delete revision', async t => {
+  const revisions = [
+    {
+      _id: new mongo.ObjectId(),
+      codeCommune: '00000',
+      current: true,
+      status: 'published',
+      publishedAt: new Date('01-03-2000').toISOString()
+
+    },
+    {
+      _id: new mongo.ObjectId(),
+      codeCommune: '00000',
+      current: false,
+      status: 'published',
+      publishedAt: new Date('01-01-2000').toISOString()
+    },
+    {
+      _id: new mongo.ObjectId(),
+      codeCommune: '00000',
+      current: false,
+      status: 'published',
+      publishedAt: new Date('01-02-2000').toISOString()
+    }
+  ]
+
+  const files = [
+    {
+      _id: new mongo.ObjectId(),
+      revisionId: revisions[0]._id
+    },
+    {
+      _id: new mongo.ObjectId(),
+      revisionId: revisions[0]._id
+    }
+  ]
+
+  await mongo.db.collection('revisions').insertMany(revisions)
+  await mongo.db.collection('file').insertMany(files)
+
+  const server = await getApp()
+  const res = await request(server)
+    .delete(`/revisions/${revisions[0]._id}`)
+    .set('Authorization', `Token ${process.env.ADMIN_TOKEN}`)
+    .expect(200)
+
+  // Check response
+  t.is(res.body.current, true)
+  t.is(res.body._id, revisions[2]._id.toHexString())
+  // Check revision and file are deleted
+  const resR1 = await mongo.db.collection('revisions').findOne({_id: revisions[0]._id})
+  t.is(resR1, null)
+  const resF1 = await mongo.db.collection('files').findOne({_id: files[0]._id})
+  t.is(resF1, null)
+  const resF2 = await mongo.db.collection('files').findOne({_id: files[1]._id})
+  t.is(resF2, null)
+  // Check other revision
+  const resR2 = await mongo.db.collection('revisions').findOne({_id: revisions[1]._id})
+  t.is(resR2.current, false)
+  const resR3 = await mongo.db.collection('revisions').findOne({_id: revisions[2]._id})
+  t.is(resR3.current, true)
+})
+
+test.serial('Delete revision 403', async t => {
+  const revisions = [
+    {
+      _id: new mongo.ObjectId(),
+      codeCommune: '00000',
+      current: true,
+      status: 'published',
+      publishedAt: new Date('01-03-2000').toISOString()
+    }
+  ]
+
+  const files = [
+    {
+      _id: new mongo.ObjectId(),
+      revisionId: revisions[0]._id
+    },
+    {
+      _id: new mongo.ObjectId(),
+      revisionId: revisions[0]._id
+    }
+  ]
+
+  await mongo.db.collection('revisions').insertMany(revisions)
+  await mongo.db.collection('file').insertMany(files)
+
+  const server = await getApp()
+  await request(server)
+    .delete(`/revisions/${revisions[0]._id}`)
+    .set('Authorization', 'Token xxxx')
+    .expect(401)
+
+  t.pass()
+})
+
+test.serial('Delete revision only one current', async t => {
+  const revisions = [
+    {
+      _id: new mongo.ObjectId(),
+      codeCommune: '00000',
+      current: true,
+      status: 'published',
+      publishedAt: new Date('01-03-2000').toISOString()
+    }
+  ]
+
+  const files = [
+    {
+      _id: new mongo.ObjectId(),
+      revisionId: revisions[0]._id
+    },
+    {
+      _id: new mongo.ObjectId(),
+      revisionId: revisions[0]._id
+    }
+  ]
+
+  await mongo.db.collection('revisions').insertMany(revisions)
+  await mongo.db.collection('file').insertMany(files)
+
+  const server = await getApp()
+  await request(server)
+    .delete(`/revisions/${revisions[0]._id}`)
+    .set('Authorization', `Token ${process.env.ADMIN_TOKEN}`)
+    .expect(500)
+
+  t.pass()
+})
+
+test.serial('Delete revision not current', async t => {
+  const revisions = [
+    {
+      _id: new mongo.ObjectId(),
+      codeCommune: '00000',
+      current: true,
+      status: 'published',
+      publishedAt: new Date('01-03-2000').toISOString()
+
+    },
+    {
+      _id: new mongo.ObjectId(),
+      codeCommune: '00000',
+      current: false,
+      status: 'published',
+      publishedAt: new Date('01-01-2000').toISOString()
+    }
+  ]
+
+  const files = [
+    {
+      _id: new mongo.ObjectId(),
+      revisionId: revisions[0]._id
+    },
+    {
+      _id: new mongo.ObjectId(),
+      revisionId: revisions[0]._id
+    }
+  ]
+
+  await mongo.db.collection('revisions').insertMany(revisions)
+  await mongo.db.collection('file').insertMany(files)
+
+  const server = await getApp()
+  await request(server)
+    .delete(`/revisions/${revisions[1]._id}`)
+    .set('Authorization', `Token ${process.env.ADMIN_TOKEN}`)
+    .expect(400)
+
+  t.pass()
 })

--- a/lib/revisions/model.js
+++ b/lib/revisions/model.js
@@ -290,6 +290,40 @@ async function getFirstRevisionsPublishedByCommune() {
   ]).toArray()
 }
 
+async function deleteRevision(revision) {
+  try {
+    // Vérouille la publication d'autre révision sur la commune
+    await Commune.lockPublishing(revision.codeCommune)
+    // Récupère la dernière publication valide
+    const lastValidRevision = await mongo.db.collection('revisions')
+      .find({codeCommune: revision.codeCommune, status: 'published', current: false})
+      .sort({publishedAt: -1})
+      .limit(1)
+      .toArray()
+
+    if (lastValidRevision.length <= 0) {
+      throw createError(400, `La dernière révision valide de la commune ${revision.codeCommune} ne peut pas être supprimée`)
+    }
+
+    // Si la dernière publication valide existe, la passe en courante
+    lastValidRevision[0].current = true
+    await mongo.db.collection('revisions').updateOne(
+      {_id: lastValidRevision[0]._id},
+      {$set: {current: true}}
+    )
+
+    // Si la dernière publication valide existe, supprime l'ancienne revision courante
+    await mongo.db.collection('files').deleteMany({revisionId: revision._id})
+    await mongo.db.collection('revisions').deleteOne({_id: revision._id})
+    return lastValidRevision[0]
+  } catch (error) {
+    throw new Error(error)
+  } finally {
+    // Déverrouille la publication à d'autres révisions pour cette commune
+    await Commune.unlockPublishing(revision.codeCommune)
+  }
+}
+
 module.exports = {
   createRevision,
   setFile,
@@ -306,5 +340,6 @@ module.exports = {
   expandWithClient,
   expandWithClients,
   getRevisionsPublishedBetweenDate,
-  getFirstRevisionsPublishedByCommune
+  getFirstRevisionsPublishedByCommune,
+  deleteRevision
 }

--- a/lib/revisions/model.js
+++ b/lib/revisions/model.js
@@ -229,6 +229,10 @@ function getRevisionsByCommune(codeCommune) {
   return mongo.db.collection('revisions').find({codeCommune, status: 'published'}).sort({publishedAt: 1}).toArray()
 }
 
+function getAllRevisionsByCommune(codeCommune) {
+  return mongo.db.collection('revisions').find({codeCommune}).sort({publishedAt: -1}).toArray()
+}
+
 async function getCurrentRevisions(publishedSince) {
   const publishedSinceQuery = publishedSince ? {publishedAt: {$gt: publishedSince}} : {}
 
@@ -295,6 +299,7 @@ module.exports = {
   fetchRevision,
   getCurrentRevision,
   getRevisionsByCommune,
+  getAllRevisionsByCommune,
   computeRevision,
   getCurrentRevisions,
   getRelatedHabilitation,

--- a/lib/revisions/routes.js
+++ b/lib/revisions/routes.js
@@ -6,7 +6,7 @@ const {authClient, ensureCodeCommune, ensureCommuneActuelle, authRevision} = req
 const w = require('../util/w')
 const rawBodyParser = require('../util/raw-body-parser')
 const {validateBAL} = require('./validate-bal')
-const {fetchRevision, getCurrentRevision, getRevisionsByCommune, createRevision, setFile, getFiles, getFileData, publishRevision, computeRevision, getCurrentRevisions, getRelatedHabilitation, expandWithClient, expandWithClients} = require('./model')
+const {fetchRevision, getCurrentRevision, getRevisionsByCommune, getAllRevisionsByCommune, createRevision, setFile, getFiles, getFileData, publishRevision, computeRevision, getCurrentRevisions, getRelatedHabilitation, expandWithClient, expandWithClients} = require('./model')
 
 async function revisionsRoutes() {
   const app = new express.Router()
@@ -69,6 +69,13 @@ async function revisionsRoutes() {
 
   app.get('/communes/:codeCommune/revisions', w(async (req, res) => {
     const revisions = await getRevisionsByCommune(req.codeCommune)
+    const revisionsWithPublicClients = await Promise.all(revisions.map(r => expandWithClient(r)))
+
+    res.send(revisionsWithPublicClients)
+  }))
+
+  app.get('/communes/:codeCommune/revisions/all', w(async (req, res) => {
+    const revisions = await getAllRevisionsByCommune(req.codeCommune)
     const revisionsWithPublicClients = await Promise.all(revisions.map(r => expandWithClient(r)))
 
     res.send(revisionsWithPublicClients)

--- a/lib/revisions/routes.js
+++ b/lib/revisions/routes.js
@@ -2,11 +2,14 @@ const express = require('express')
 const {isString, isPlainObject} = require('lodash')
 const createError = require('http-errors')
 const errorHandler = require('../util/error-handler')
-const {authClient, ensureCodeCommune, ensureCommuneActuelle, authRevision} = require('../util/middlewares')
+const {authClient, ensureCodeCommune, ensureCommuneActuelle, authRevision, ensureIsAdmin} = require('../util/middlewares')
 const w = require('../util/w')
 const rawBodyParser = require('../util/raw-body-parser')
 const {validateBAL} = require('./validate-bal')
-const {fetchRevision, getCurrentRevision, getRevisionsByCommune, getAllRevisionsByCommune, createRevision, setFile, getFiles, getFileData, publishRevision, computeRevision, getCurrentRevisions, getRelatedHabilitation, expandWithClient, expandWithClients} = require('./model')
+const {fetchRevision, getCurrentRevision, getRevisionsByCommune,
+  getAllRevisionsByCommune, createRevision, setFile, getFiles,
+  getFileData, publishRevision, computeRevision, getCurrentRevisions,
+  getRelatedHabilitation, expandWithClient, expandWithClients, deleteRevision} = require('./model')
 
 async function revisionsRoutes() {
   const app = new express.Router()
@@ -116,6 +119,15 @@ async function revisionsRoutes() {
     const revisionWithPublicClient = await expandWithClient(req.revision)
 
     res.send({...revisionWithPublicClient, files})
+  }))
+
+  app.delete('/revisions/:revisionId', ensureIsAdmin, w(async (req, res) => {
+    if (!req.revision.current) {
+      throw createError(400, 'La révision n’est pas supprimable')
+    }
+
+    const newCurrentRevision = await deleteRevision(req.revision)
+    res.send(newCurrentRevision)
   }))
 
   app.put('/revisions/:revisionId/files/bal', authClient, authRevision, rawBodyParser(), w(async (req, res) => {


### PR DESCRIPTION
## Context

https://github.com/BaseAdresseNationale/api-depot/issues/33

## Fonctionnalité

Ajout de la route DELETE `revisions/:revisionId` pour supprimer la revisions courante et placer la dernière en date a la place