### PR TITLE
Fix error <<FILE>> Impossible dupload le fichier

### DIFF
--- a/lib/revisions/model.js
+++ b/lib/revisions/model.js
@@ -58,7 +58,13 @@ async function setFile(revision, type, {data, name}) {
   }
 
   await mongo.db.collection('files').deleteOne({revisionId: revision._id, type})
-  await s3Service.uploadS3File({filename: _id.toHexString(), data})
+  try {
+    await s3Service.uploadS3File({filename: _id.toHexString(), data})
+  } catch (error) {
+    console.error(`<<FILE>> Impossible d'upload le fichier ${revision._id}`)
+    console.error(error)
+  }
+
   await mongo.db.collection('files').insertOne(file)
   await mongo.db.collection('revisions').updateOne(
     {_id: revision._id, status: 'pending'},

--- a/lib/revisions/routes.js
+++ b/lib/revisions/routes.js
@@ -128,7 +128,6 @@ async function revisionsRoutes() {
       })
       res.send(fileMetadata)
     } catch (error) {
-      console.error(`<<FILE>> Impossible d'upload le fichier ${req.revision._id}`)
       console.error(error)
       throw createError(500, 'Une erreur est survenue lors du téléchargement du fichier BAL')
     }


### PR DESCRIPTION
## Context

En local sur mes-adresse, j'ai essayé de publier une BAL (sans les var d'ENV sur api-depot pour s3) a ma grande surprise, la requète /revisions/:revisionId/files/bala tous simplement échouée. Alors que je m'attendais a que cela soit au moins mit en DB dans mongo et non craché une erreur.

<img width="847" alt="Capture d’écran 2024-01-08 à 17 30 30" src="https://github.com/BaseAdresseNationale/api-depot/assets/8143924/c396ae6a-80a9-4bcf-b351-8337eb417ad0">
