### PR TITLE
feat: notify partners when force publish

### DIFF
--- a/lib/emails/__tests__/notify-partners-on-force-publish.js
+++ b/lib/emails/__tests__/notify-partners-on-force-publish.js
@@ -1,0 +1,156 @@
+const test = require('ava')
+const formatEmail = require('../notify-partners-on-force-publish')
+
+test('notify partner on force publish via mes-adresses', t => {
+  const commune = {nom: 'Bourg-La-Reine'}
+  const balId = '123456'
+
+  const expectedTextBody = `
+<!DOCTYPE html>
+<html lang="fr">
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Demande de code d’identification</title>
+  <style>
+    body {
+      background-color: #F5F6F7;
+      color: #234361;
+      font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+      margin: auto;
+      padding: 25px;
+    }
+
+    img {
+      max-height: 45px;
+      background-color: #F5F6F7;
+    }
+
+    .container {
+      background-color: #ebeff3;
+      padding: 25px;
+    }
+
+    .token {
+      font-weight: bold;
+    }
+
+    .title {
+      align-items: center;
+      border-bottom: 1px solid #E4E7EB;
+      justify-content: center;
+      margin-top: 35px;
+      min-height: 8em;
+      padding: 10px;
+      text-align: center;
+    }
+
+    .infos > div {
+      margin-top: 10px;
+    }
+  </style>
+</head>
+
+<body>
+  <div>
+    <img src="$$API_URL$$/public/images/logo-adresse.png" alt="Logo République Française">
+  </div>
+  <div class="title">
+    <h3 style="margin:0; mso-line-height-rule:exactly;">
+      La commune de Bourg-La-Reine a repris la main sur sa Base Adresse Locale
+    </h3>
+  </div>
+
+  <p>
+    Nous vous informons que la commune Bourg-La-Reine a publié une Base Adresse Locale via l'outil Mes-Adresses : <a href="https://mes-adresses.data.gouv.fr/bal/123456" />. Les prochaines modifications d'adressages que vous effectuerez pour cette commune ne seront donc pas publiés dans la Base Adresse Nationale.
+  </p>
+
+  <p>
+    Si vous pensez qu'il s'agit d'une erreur, merci de contacter directement la commune de Bourg-La-Reine. Afin de vous permettre de continuer à mettre à jour les adresses de la commune de Bourg-La-Reine, cette dernière devra prendre contact avec nous.
+  </p>
+
+  <p><i>L’équipe adresse.data.gouv.fr</i></p>
+</body>
+</html>
+`
+
+  t.is(formatEmail({commune, balId, isDemoMode: false}).html, expectedTextBody)
+})
+
+test('notify partner on force publish via formulaire', t => {
+  const commune = {nom: 'Antony'}
+
+  const expectedTextBody = `
+<!DOCTYPE html>
+<html lang="fr">
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Demande de code d’identification</title>
+  <style>
+    body {
+      background-color: #F5F6F7;
+      color: #234361;
+      font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+      margin: auto;
+      padding: 25px;
+    }
+
+    img {
+      max-height: 45px;
+      background-color: #F5F6F7;
+    }
+
+    .container {
+      background-color: #ebeff3;
+      padding: 25px;
+    }
+
+    .token {
+      font-weight: bold;
+    }
+
+    .title {
+      align-items: center;
+      border-bottom: 1px solid #E4E7EB;
+      justify-content: center;
+      margin-top: 35px;
+      min-height: 8em;
+      padding: 10px;
+      text-align: center;
+    }
+
+    .infos > div {
+      margin-top: 10px;
+    }
+  </style>
+</head>
+
+<body>
+  <div>
+    <img src="$$API_URL$$/public/images/logo-adresse.png" alt="Logo République Française">
+  </div>
+  <div class="title">
+    <h3 style="margin:0; mso-line-height-rule:exactly;">
+      La commune de Antony a repris la main sur sa Base Adresse Locale
+    </h3>
+  </div>
+
+  <p>
+    Nous vous informons que la commune Antony a publié une Base Adresse Locale. Les prochaines modifications d'adressages que vous effectuerez pour cette commune ne seront donc pas publiés dans la Base Adresse Nationale.
+  </p>
+
+  <p>
+    Si vous pensez qu'il s'agit d'une erreur, merci de contacter directement la commune de Antony. Afin de vous permettre de continuer à mettre à jour les adresses de la commune de Antony, cette dernière devra prendre contact avec nous.
+  </p>
+
+  <p><i>L’équipe adresse.data.gouv.fr</i></p>
+</body>
+</html>
+`
+
+  t.is(formatEmail({commune}).html, expectedTextBody)
+})
+

--- a/lib/emails/__tests__/notify-partners-on-force-publish.js
+++ b/lib/emails/__tests__/notify-partners-on-force-publish.js
@@ -63,7 +63,7 @@ test('notify partner on force publish via mes-adresses', t => {
   </div>
 
   <p>
-    Nous vous informons que la commune Bourg-La-Reine a publié une Base Adresse Locale via l'outil Mes-Adresses : <a href="https://mes-adresses.data.gouv.fr/bal/123456" />. Les prochaines modifications d'adressages que vous effectuerez pour cette commune ne seront donc pas publiés dans la Base Adresse Nationale.
+    Nous vous informons que la commune Bourg-La-Reine a publié une Base Adresse Locale via l'outil Mes-Adresses : <a href="https://mes-adresses.data.gouv.fr/bal/123456">BAL de Bourg-La-Reine</a>. Les prochaines modifications d'adressages que vous effectuerez pour cette commune ne seront donc pas publiés dans la Base Adresse Nationale.
   </p>
 
   <p>

--- a/lib/emails/notify-partners-on-force-publish.js
+++ b/lib/emails/notify-partners-on-force-publish.js
@@ -1,0 +1,80 @@
+const {template} = require('lodash')
+
+const bodyTemplate = template(`
+  <!DOCTYPE html>
+  <html lang="fr">
+
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Demande de code d’identification</title>
+    <style>
+      body {
+        background-color: #F5F6F7;
+        color: #234361;
+        font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        margin: auto;
+        padding: 25px;
+      }
+
+      img {
+        max-height: 45px;
+        background-color: #F5F6F7;
+      }
+
+      .container {
+        background-color: #ebeff3;
+        padding: 25px;
+      }
+
+      .token {
+        font-weight: bold;
+      }
+
+      .title {
+        align-items: center;
+        border-bottom: 1px solid #E4E7EB;
+        justify-content: center;
+        margin-top: 35px;
+        min-height: 8em;
+        padding: 10px;
+        text-align: center;
+      }
+
+      .infos > div {
+          margin-top: 10px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div>
+      <img src="$$API_URL$$/public/images/logo-adresse.png" alt="Logo République Française">
+    </div>
+    <div class="title">
+      <h3 style="margin:0; mso-line-height-rule:exactly;">
+        La commune de <%= commune.nom %> a repris la main sur sa Base Adresse Locale
+      </h3>
+    </div>
+
+    <p>
+      Nous vous informons que la commune <%= commune.nom %> a publié une Base Adresse Locale via l'outil Mes-Adresses. Les prochaines modifications d'adressages que vous effectuerez pour cette commune ne seront donc pas publiés dans la Base Adresse Nationale.
+    </p>
+
+    <p><i>L’équipe adresse.data.gouv.fr</i></p>
+  </body>
+  </html>
+`)
+
+function formatEmail({commune, prevCurrentRevision, currentRevision}) {
+  return {
+    subject: `La commune de ${commune.nom} a repris la main sur sa Base Adresse Locale`,
+    html: bodyTemplate({
+      commune,
+      prevCurrentRevision,
+      currentRevision
+    })
+  }
+}
+
+module.exports = formatEmail

--- a/lib/emails/notify-partners-on-force-publish.js
+++ b/lib/emails/notify-partners-on-force-publish.js
@@ -58,7 +58,7 @@ const templateStr = balId => `
   </div>
 
   <p>
-    Nous vous informons que la commune <%= commune.nom %> a publié une Base Adresse Locale${balId ? ` via l'outil Mes-Adresses : <a href="https://mes-adresses.data.gouv.fr/bal/${balId}" />` : ''}. Les prochaines modifications d'adressages que vous effectuerez pour cette commune ne seront donc pas publiés dans la Base Adresse Nationale.
+    Nous vous informons que la commune <%= commune.nom %> a publié une Base Adresse Locale${balId ? ` via l'outil Mes-Adresses : <a href="https://mes-adresses.data.gouv.fr/bal/${balId}">BAL de <%= commune.nom %></a>` : ''}. Les prochaines modifications d'adressages que vous effectuerez pour cette commune ne seront donc pas publiés dans la Base Adresse Nationale.
   </p>
 
   <p>

--- a/lib/emails/notify-partners-on-force-publish.js
+++ b/lib/emails/notify-partners-on-force-publish.js
@@ -1,79 +1,81 @@
 const {template} = require('lodash')
 
-const bodyTemplate = template(`
-  <!DOCTYPE html>
-  <html lang="fr">
+const templateStr = balId => `
+<!DOCTYPE html>
+<html lang="fr">
 
-  <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Demande de code d’identification</title>
-    <style>
-      body {
-        background-color: #F5F6F7;
-        color: #234361;
-        font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-        margin: auto;
-        padding: 25px;
-      }
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Demande de code d’identification</title>
+  <style>
+    body {
+      background-color: #F5F6F7;
+      color: #234361;
+      font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+      margin: auto;
+      padding: 25px;
+    }
 
-      img {
-        max-height: 45px;
-        background-color: #F5F6F7;
-      }
+    img {
+      max-height: 45px;
+      background-color: #F5F6F7;
+    }
 
-      .container {
-        background-color: #ebeff3;
-        padding: 25px;
-      }
+    .container {
+      background-color: #ebeff3;
+      padding: 25px;
+    }
 
-      .token {
-        font-weight: bold;
-      }
+    .token {
+      font-weight: bold;
+    }
 
-      .title {
-        align-items: center;
-        border-bottom: 1px solid #E4E7EB;
-        justify-content: center;
-        margin-top: 35px;
-        min-height: 8em;
-        padding: 10px;
-        text-align: center;
-      }
+    .title {
+      align-items: center;
+      border-bottom: 1px solid #E4E7EB;
+      justify-content: center;
+      margin-top: 35px;
+      min-height: 8em;
+      padding: 10px;
+      text-align: center;
+    }
 
-      .infos > div {
-          margin-top: 10px;
-      }
-    </style>
-  </head>
+    .infos > div {
+        margin-top: 10px;
+    }
+  </style>
+</head>
 
-  <body>
-    <div>
-      <img src="$$API_URL$$/public/images/logo-adresse.png" alt="Logo République Française">
-    </div>
-    <div class="title">
-      <h3 style="margin:0; mso-line-height-rule:exactly;">
-        La commune de <%= commune.nom %> a repris la main sur sa Base Adresse Locale
-      </h3>
-    </div>
+<body>
+  <div>
+    <img src="$$API_URL$$/public/images/logo-adresse.png" alt="Logo République Française">
+  </div>
+  <div class="title">
+    <h3 style="margin:0; mso-line-height-rule:exactly;">
+      La commune de <%= commune.nom %> a repris la main sur sa Base Adresse Locale
+    </h3>
+  </div>
 
-    <p>
-      Nous vous informons que la commune <%= commune.nom %> a publié une Base Adresse Locale via l'outil Mes-Adresses. Les prochaines modifications d'adressages que vous effectuerez pour cette commune ne seront donc pas publiés dans la Base Adresse Nationale.
-    </p>
+  <p>
+    Nous vous informons que la commune <%= commune.nom %> a publié une Base Adresse Locale${balId && ` via l'outil Mes-Adresses : <a href="https://mes-adresses.data.gouv.fr/bal/${balId}" />`}. Les prochaines modifications d'adressages que vous effectuerez pour cette commune ne seront donc pas publiés dans la Base Adresse Nationale.
+  </p>
 
-    <p><i>L’équipe adresse.data.gouv.fr</i></p>
-  </body>
-  </html>
-`)
+  <p>
+    Si vous pensez qu'il s'agit d'une erreur, merci de contacter directement la commune de <%= commune.nom %>. Afin de vous permettre de continuer à mettre à jour les adresses de la commune de <%= commune.nom %>, cette dernière devra prendre contact avec nous.
+  </p>
 
-function formatEmail({commune, prevCurrentRevision, currentRevision}) {
+  <p><i>L’équipe adresse.data.gouv.fr</i></p>
+</body>
+</html>
+`
+
+function formatEmail({commune, balId}) {
+  const templateString = templateStr(balId)
+  const html = ({commune, balId}) => template(templateString)({commune, balId})
   return {
     subject: `La commune de ${commune.nom} a repris la main sur sa Base Adresse Locale`,
-    html: bodyTemplate({
-      commune,
-      prevCurrentRevision,
-      currentRevision
-    })
+    html
   }
 }
 

--- a/lib/emails/notify-partners-on-force-publish.js
+++ b/lib/emails/notify-partners-on-force-publish.js
@@ -42,7 +42,7 @@ const templateStr = balId => `
     }
 
     .infos > div {
-        margin-top: 10px;
+      margin-top: 10px;
     }
   </style>
 </head>
@@ -58,7 +58,7 @@ const templateStr = balId => `
   </div>
 
   <p>
-    Nous vous informons que la commune <%= commune.nom %> a publié une Base Adresse Locale${balId && ` via l'outil Mes-Adresses : <a href="https://mes-adresses.data.gouv.fr/bal/${balId}" />`}. Les prochaines modifications d'adressages que vous effectuerez pour cette commune ne seront donc pas publiés dans la Base Adresse Nationale.
+    Nous vous informons que la commune <%= commune.nom %> a publié une Base Adresse Locale${balId ? ` via l'outil Mes-Adresses : <a href="https://mes-adresses.data.gouv.fr/bal/${balId}" />` : ''}. Les prochaines modifications d'adressages que vous effectuerez pour cette commune ne seront donc pas publiés dans la Base Adresse Nationale.
   </p>
 
   <p>
@@ -72,7 +72,7 @@ const templateStr = balId => `
 
 function formatEmail({commune, balId}) {
   const templateString = templateStr(balId)
-  const html = ({commune, balId}) => template(templateString)({commune, balId})
+  const html = template(templateString)({commune, balId})
   return {
     subject: `La commune de ${commune.nom} a repris la main sur sa Base Adresse Locale`,
     html

--- a/lib/revisions/__tests__/notify-partners.js
+++ b/lib/revisions/__tests__/notify-partners.js
@@ -1,0 +1,132 @@
+const test = require('ava')
+const sinon = require('sinon')
+const proxyquire = require('proxyquire')
+
+const mockClients = {
+  '641493ac8259bc0027670f04': {
+    _id: '641493ac8259bc0027670f04',
+    nom: 'Mes Adresses',
+    id: 'mes-adresses',
+    chefDeFile: '641492230abe143383ddd3dg',
+    mandataire: '641492230abe143383ddd3de'
+  },
+  '641492230abe143383ddd3df': {
+    _id: '641492230abe143383ddd3df',
+    nom: 'Formulaire de publication',
+    id: 'formulaire-publication',
+    chefDeFile: '641492230abe143383ddd3dg',
+    mandataire: '641492230abe143383ddd3de'
+  },
+  '63f5eb7db804021c67e4e4dc': {
+    _id: '63f5eb7db804021c67e4e4dc',
+    nom: 'RGD Savoie',
+    chefDeFile: '63f5eb7db804021c67e4e4dd',
+    mandataire: '63f5eb7db804021c67e4e4de'
+  }
+}
+
+function mockFetchClient(clientId) {
+  return mockClients[clientId]
+}
+
+const mockChefsDeFile = {
+  '641492230abe143383ddd3dg': {
+    _id: '641492230abe143383ddd3dg',
+    email: 'adresse@data.gouv.fr'
+  },
+  '63f5eb7db804021c67e4e4dd': {
+    _id: '63f5eb7db804021c67e4e4dd',
+    email: 'contact@rdgd-savoie.fr'
+  }
+}
+
+function mockFetchChefDeFile(chefDeFileId) {
+  return mockChefsDeFile[chefDeFileId]
+}
+
+const mockMandataires = {
+  '641492230abe143383ddd3de': {
+    _id: '641492230abe143383ddd3de',
+    email: 'adresse@data.gouv.fr'
+  },
+  '63f5eb7db804021c67e4e4de': {
+    _id: '63f5eb7db804021c67e4e4de',
+    email: 'contact@rdgd-savoie.fr'
+  }
+}
+
+function mockFetchMandataire(mandataireId) {
+  return mockMandataires[mandataireId]
+}
+
+const initNotifyPartners = spy => proxyquire('../notify-partners', {
+  '../clients/model': {
+    fetch: mockFetchClient
+  },
+  '../chefs-de-file/model': {
+    fetch: mockFetchChefDeFile
+  },
+  '../mandataires/model': {
+    fetch: mockFetchMandataire
+  },
+  '../util/sendmail': {
+    sendMail: spy
+  }
+})
+
+test('should send email on force publish via mes-adresses', async t => {
+  const sendMailSpy = sinon.spy()
+  const notifyPartners = initNotifyPartners(sendMailSpy)
+  const prevRevision = {
+    client: '63f5eb7db804021c67e4e4dc',
+    codeCommune: '31591'
+  }
+  const currentRevision = {
+    client: '641493ac8259bc0027670f04',
+    codeCommune: '31591'
+  }
+  await notifyPartners.notifyPartnersOnForcePublish({prevRevision, currentRevision})
+  t.true(sendMailSpy.calledOnce)
+})
+
+test('should send email on force publish via formulaire', async t => {
+  const sendMailSpy = sinon.spy()
+  const notifyPartners = initNotifyPartners(sendMailSpy)
+  const prevRevision = {
+    client: '63f5eb7db804021c67e4e4dc',
+    codeCommune: '31591'
+  }
+  const currentRevision = {
+    client: '641492230abe143383ddd3df',
+    codeCommune: '31591'
+  }
+  await notifyPartners.notifyPartnersOnForcePublish({prevRevision, currentRevision})
+  t.true(sendMailSpy.calledOnce)
+})
+
+test('should not send email when no prev revision', async t => {
+  const sendMailSpy = sinon.spy()
+  const notifyPartners = initNotifyPartners(sendMailSpy)
+  const currentRevision = {
+    client: '641492230abe143383ddd3df',
+    codeCommune: '31591'
+  }
+  await notifyPartners.notifyPartnersOnForcePublish({prevRevision: null, currentRevision})
+  t.false(sendMailSpy.calledOnce)
+})
+
+test('should not send email when prev revision was published by a managed client', async t => {
+  const sendMailSpy = sinon.spy()
+  const notifyPartners = initNotifyPartners(sendMailSpy)
+  const prevRevision = {
+    client: '641492230abe143383ddd3df',
+    codeCommune: '31591'
+  }
+  const currentRevision = {
+    client: '641492230abe143383ddd3df',
+    codeCommune: '31591'
+  }
+  await notifyPartners.notifyPartnersOnForcePublish({prevRevision, currentRevision})
+  t.false(sendMailSpy.calledOnce)
+})
+

--- a/lib/revisions/model.js
+++ b/lib/revisions/model.js
@@ -11,6 +11,7 @@ const Commune = require('../communes/model')
 const {s3Service} = require('../files/s3.service')
 const {applyValidateBAL} = require('./validate-bal')
 const {notifyPublication} = require('./slack')
+const {notifyPartnersOnForcePublish} = require('./notify-partners')
 
 async function createRevision({context, codeCommune, client}) {
   const now = new Date()
@@ -186,6 +187,8 @@ async function publishRevision(revision, {client, habilitation}) {
   }
 
   try {
+    const oldCurrentRevision = await getCurrentRevision(revision.codeCommune)
+
     await mongo.db.collection('revisions').updateOne({_id: revision._id}, {$set: changes})
 
     // On supprime le flag current pour toutes les anciennes révisions publiées de cette commune
@@ -217,6 +220,13 @@ async function publishRevision(revision, {client, habilitation}) {
       publicationType,
       habilitationStrategy: habilitation?.strategy.type,
       client: publicClient
+    })
+
+    // On notifie les partenaires si une commune qui était gérée par un partenaire
+    //  force une publication via mes-adresses
+    await notifyPartnersOnForcePublish({
+      oldCurrentRevision,
+      currentRevision: revision
     })
 
     return {...revision, ...changes}

--- a/lib/revisions/model.js
+++ b/lib/revisions/model.js
@@ -187,7 +187,7 @@ async function publishRevision(revision, {client, habilitation}) {
   }
 
   try {
-    const oldCurrentRevision = await getCurrentRevision(revision.codeCommune)
+    const prevRevision = await getCurrentRevision(revision.codeCommune)
 
     await mongo.db.collection('revisions').updateOne({_id: revision._id}, {$set: changes})
 
@@ -225,7 +225,7 @@ async function publishRevision(revision, {client, habilitation}) {
     // On notifie les partenaires si une commune qui était gérée par un partenaire
     //  force une publication via mes-adresses
     await notifyPartnersOnForcePublish({
-      oldCurrentRevision,
+      prevRevision,
       currentRevision: revision
     })
 

--- a/lib/revisions/notify-partners.js
+++ b/lib/revisions/notify-partners.js
@@ -1,0 +1,31 @@
+const createNotifyPartnersOnForcePublishEmail = require('../emails/notify-partners-on-force-publish')
+const {sendMail} = require('../util/sendmail')
+
+const MES_ADRESSES_CLIENT_ID = 'mes-adresses'
+
+async function notifyPartnersOnForcePublish({oldCurrentRevision, currentRevision}) {
+  console.log('oldCurrentRevision', oldCurrentRevision)
+  console.log('currentRevision', currentRevision)
+  if (!oldCurrentRevision) {
+    return
+  }
+
+  try {
+    if (currentRevision.client.id === MES_ADRESSES_CLIENT_ID && oldCurrentRevision.client.id !== MES_ADRESSES_CLIENT_ID) {
+      const mandataire = oldCurrentRevision.mandataire
+      const partnerEmail = mandataire.email
+
+      // On n'envoie pas de mail si la révision avait été publiée par un de nos clients API-Depot (Moissonneur, Formulaire, Guichet, etc.)
+      if (!partnerEmail || partnerEmail === process.env.SMTP_FROM) {
+        return
+      }
+
+      const email = createNotifyPartnersOnForcePublishEmail({oldCurrentRevision, currentRevision})
+      await sendMail(email, [partnerEmail])
+    }
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+module.exports = {notifyPartnersOnForcePublish}

--- a/lib/revisions/notify-partners.js
+++ b/lib/revisions/notify-partners.js
@@ -1,7 +1,9 @@
 const createNotifyPartnersOnForcePublishEmail = require('../emails/notify-partners-on-force-publish')
 const {sendMail} = require('../util/sendmail')
-
-const DEMO_MODE = process.env.DEMO_MODE === '1'
+const Client = require('../clients/model')
+const Mandataire = require('../mandataires/model')
+const ChefDeFile = require('../chefs-de-file/model')
+const {getCommune} = require('../util/cog')
 
 const MANAGED_CLIENTS = {
   MES_ADRESSES: 'mes-adresses',
@@ -10,29 +12,35 @@ const MANAGED_CLIENTS = {
   GUICHET_ADRESSE: 'guichet-adresse'
 }
 
-function isPublishedByManagedClient(revision) {
-  return Object.values(MANAGED_CLIENTS).includes(revision.client.id)
+function isPublishedByManagedClient(client) {
+  return Object.values(MANAGED_CLIENTS).includes(client.id)
 }
 
 async function notifyPartnersOnForcePublish({oldCurrentRevision, currentRevision}) {
   // Pas d'envoie si il s'agit d'une première publication
-  // ou qu'on est sur l'environnement de démo
-  if (!oldCurrentRevision || DEMO_MODE) {
-    return
-  }
-
-  // On n'envoie pas de mail si la révision antérieure avait été publiée
-  // par un de nos clients (Mes-adresses, Moissonneur, Formulaire, Guichet)
-  if (isPublishedByManagedClient(oldCurrentRevision.client.id)) {
+  if (!oldCurrentRevision) {
     return
   }
 
   try {
+    const currentClient = await Client.fetch(currentRevision.client.id)
+    const oldClient = await Client.fetch(oldCurrentRevision.client.id)
+
+    // On n'envoie pas de mail si la révision antérieure avait été publiée
+    // par un de nos clients (Mes-adresses, Moissonneur, Formulaire, Guichet)
+    if (!currentClient || !oldClient || isPublishedByManagedClient(oldClient)) {
+      return
+    }
+
     // On envoie un mail si la révision courante a été publiée par mes-adresses ou formulaire
     // et que la révision antérieure avait été par un client non géré
-    if (currentRevision.client.id === MANAGED_CLIENTS.MES_ADRESSES || currentRevision.client.id === MANAGED_CLIENTS.FORMULAIRE_PUBLICATION) {
-      const contactEmail = oldCurrentRevision.chefDeFile?.email || oldCurrentRevision.mandataire?.email
-      const email = createNotifyPartnersOnForcePublishEmail({oldCurrentRevision, currentRevision})
+    if (currentClient.id === MANAGED_CLIENTS.MES_ADRESSES || currentClient.id === MANAGED_CLIENTS.FORMULAIRE_PUBLICATION) {
+      const chefDeFile = await ChefDeFile.fetch(oldClient.chefDeFile)
+      const mandataire = await Mandataire.fetch(oldClient.mandataire)
+      const contactEmail = chefDeFile?.email || mandataire?.email
+      const commune = getCommune(currentRevision.codeCommune)
+      const balId = currentRevision.context?.extras?.balId
+      const email = createNotifyPartnersOnForcePublishEmail({commune, balId})
       await sendMail(email, contactEmail ? [contactEmail] : [])
     }
   } catch (error) {

--- a/lib/revisions/notify-partners.js
+++ b/lib/revisions/notify-partners.js
@@ -12,31 +12,31 @@ const MANAGED_CLIENTS = {
   GUICHET_ADRESSE: 'guichet-adresse'
 }
 
-function isPublishedByManagedClient(client) {
+function wasPublishedByManagedClient(client) {
   return Object.values(MANAGED_CLIENTS).includes(client.id)
 }
 
-async function notifyPartnersOnForcePublish({oldCurrentRevision, currentRevision}) {
+async function notifyPartnersOnForcePublish({prevRevision, currentRevision}) {
   // Pas d'envoie si il s'agit d'une première publication
-  if (!oldCurrentRevision) {
+  if (!prevRevision) {
     return
   }
 
   try {
-    const currentClient = await Client.fetch(currentRevision.client.id)
-    const oldClient = await Client.fetch(oldCurrentRevision.client.id)
+    const currentClient = await Client.fetch(currentRevision.client)
+    const prevClient = await Client.fetch(prevRevision.client)
 
     // On n'envoie pas de mail si la révision antérieure avait été publiée
     // par un de nos clients (Mes-adresses, Moissonneur, Formulaire, Guichet)
-    if (!currentClient || !oldClient || isPublishedByManagedClient(oldClient)) {
+    if (!currentClient || !prevClient || wasPublishedByManagedClient(prevClient)) {
       return
     }
 
     // On envoie un mail si la révision courante a été publiée par mes-adresses ou formulaire
     // et que la révision antérieure avait été par un client non géré
     if (currentClient.id === MANAGED_CLIENTS.MES_ADRESSES || currentClient.id === MANAGED_CLIENTS.FORMULAIRE_PUBLICATION) {
-      const chefDeFile = await ChefDeFile.fetch(oldClient.chefDeFile)
-      const mandataire = await Mandataire.fetch(oldClient.mandataire)
+      const chefDeFile = await ChefDeFile.fetch(prevClient.chefDeFile)
+      const mandataire = await Mandataire.fetch(prevClient.mandataire)
       const contactEmail = chefDeFile?.email || mandataire?.email
       const commune = getCommune(currentRevision.codeCommune)
       const balId = currentRevision.context?.extras?.balId

--- a/lib/revisions/notify-partners.js
+++ b/lib/revisions/notify-partners.js
@@ -1,27 +1,39 @@
 const createNotifyPartnersOnForcePublishEmail = require('../emails/notify-partners-on-force-publish')
 const {sendMail} = require('../util/sendmail')
 
-const MES_ADRESSES_CLIENT_ID = 'mes-adresses'
+const DEMO_MODE = process.env.DEMO_MODE === '1'
+
+const MANAGED_CLIENTS = {
+  MES_ADRESSES: 'mes-adresses',
+  MOISSONNEUR_BAL: 'moissonneur-bal',
+  FORMULAIRE_PUBLICATION: 'formulaire-publication',
+  GUICHET_ADRESSE: 'guichet-adresse'
+}
+
+function isPublishedByManagedClient(revision) {
+  return Object.values(MANAGED_CLIENTS).includes(revision.client.id)
+}
 
 async function notifyPartnersOnForcePublish({oldCurrentRevision, currentRevision}) {
-  console.log('oldCurrentRevision', oldCurrentRevision)
-  console.log('currentRevision', currentRevision)
-  if (!oldCurrentRevision) {
+  // Pas d'envoie si il s'agit d'une première publication
+  // ou qu'on est sur l'environnement de démo
+  if (!oldCurrentRevision || DEMO_MODE) {
+    return
+  }
+
+  // On n'envoie pas de mail si la révision antérieure avait été publiée
+  // par un de nos clients (Mes-adresses, Moissonneur, Formulaire, Guichet)
+  if (isPublishedByManagedClient(oldCurrentRevision.client.id)) {
     return
   }
 
   try {
-    if (currentRevision.client.id === MES_ADRESSES_CLIENT_ID && oldCurrentRevision.client.id !== MES_ADRESSES_CLIENT_ID) {
-      const mandataire = oldCurrentRevision.mandataire
-      const partnerEmail = mandataire.email
-
-      // On n'envoie pas de mail si la révision avait été publiée par un de nos clients API-Depot (Moissonneur, Formulaire, Guichet, etc.)
-      if (!partnerEmail || partnerEmail === process.env.SMTP_FROM) {
-        return
-      }
-
+    // On envoie un mail si la révision courante a été publiée par mes-adresses ou formulaire
+    // et que la révision antérieure avait été par un client non géré
+    if (currentRevision.client.id === MANAGED_CLIENTS.MES_ADRESSES || currentRevision.client.id === MANAGED_CLIENTS.FORMULAIRE_PUBLICATION) {
+      const contactEmail = oldCurrentRevision.chefDeFile?.email || oldCurrentRevision.mandataire?.email
       const email = createNotifyPartnersOnForcePublishEmail({oldCurrentRevision, currentRevision})
-      await sendMail(email, [partnerEmail])
+      await sendMail(email, contactEmail ? [contactEmail] : [])
     }
   } catch (error) {
     console.error(error)


### PR DESCRIPTION
# Contexte 

Afin de permettre au partenaire d'être informé lorsqu'une commune reprend la main sur son adressage, nous voulons les notifier par email lors de la publication de la révision.
