### PR TITLE
fix: build-rne

### DIFF
--- a/lib/habilitations/build-rne/index.js
+++ b/lib/habilitations/build-rne/index.js
@@ -15,7 +15,7 @@ async function loadMandats(url, codeMandat, registry) {
   const rows = await getStream(
     got.stream(url, {responseType: 'buffer'})
       .pipe(csvParse({
-        separator: '\t',
+        separator: ',',
         mapHeaders({header}) {
           const headersMapping = {
             ...models.elu.headersMapping,
@@ -30,7 +30,6 @@ async function loadMandats(url, codeMandat, registry) {
         }
       }))
   )
-
   for (const row of rows) {
     const elu = models.elu.prepare(row)
     const mandat = {


### PR DESCRIPTION
## Context

La commande `yarn habilitations:build-rne` car le csv du dataset a changé ses séparateur par des virgules

## Solution

Changement des séparateur de la lib csvParse

## Recommander

Lancer la commande sur le serveur une fois mergé