### PR TITLE
Migration: new api annuaire

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,7 +1,7 @@
 MONGODB_URL=mongodb://localhost
 MONGODB_DBNAME=api-depot
 API_DEPOT_URL=https://plateforme-bal.adresse.data.gouv.fr/api-depot
-API_ETABLISSEMENTS_PUBLICS=https://etablissements-publics.api.gouv.fr/v3
+API_ANNUAIRE=https://api-lannuaire.service-public.fr/api/explore/v2.1
 SMTP_HOST=
 SMTP_PORT=
 SMTP_SECURE=YES

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Elles peuvent être définies classiquement ou en créant un fichier `.env` sur 
 | `PORT`                    | Port à utiliser pour l'API                                                  |
 | `SHOW_EMAILS`             | Indique si les courriels doivent être affichés dans les logs (`YES`)        |
 | `API_DEPOT_URL`           | URL de l'api-depot                                                          |
-| `API_ETABLISSEMENTS_PUBLICS`| URL de base de l’API des batiments publique |
+| `API_ANNURAIRE`           | URL de base de l’API des batiments publique |
 | `FC_SERVICE_URL`| URL de base du service france connect |
 | `FC_FS_ID`| Id de l'application dans france connect |
 | `SESSION_SECRET`| Champ `secret` de la session des route habilitation |

--- a/lib/habilitations/model.js
+++ b/lib/habilitations/model.js
@@ -4,15 +4,22 @@ const createError = require('http-errors')
 const mongo = require('../util/mongo')
 const Client = require('../clients/model')
 
-const API_ETABLISSEMENTS_PUBLICS = process.env.API_ETABLISSEMENTS_PUBLICS || 'https://etablissements-publics.api.gouv.fr/v3'
+const API_ANNUAIRE = process.env.API_ANNUAIRE || 'https://api-lannuaire.service-public.fr/api/explore/v2.1'
 
 async function getCommuneEmail(codeCommune) {
   try {
-    const response = await got(`${API_ETABLISSEMENTS_PUBLICS}/communes/${codeCommune}/mairie`, {responseType: 'json'})
-    const mairie = response.body.features
-      .find(m => !normalize(m.properties.nom).includes('deleguee'))
+    const url = `${API_ANNUAIRE}/catalog/datasets/api-lannuaire-administration/records?where=pivot%20LIKE%20"mairie"%20AND%20code_insee_commune=${codeCommune}`
+    const response = await got(url, {responseType: 'json'})
 
-    const {email} = mairie.properties
+    // RECUPERE LA MAIRIE PRINCIPAL
+    const mairie = response.body.results
+      .find(({nom}) => !normalize(nom).includes('deleguee'))
+
+    const email = mairie.adresse_courriel
+    if (!email || email === '') {
+      throw new Error('L’adresse email n’est pas trouvé')
+    }
+
     if (validateEmail(email)) {
       return email
     }


### PR DESCRIPTION
## Context

L'api des établissement public est souvent en retard avec l'annuaire public et certaines mairies ne peuvent pas s'habilité

La nouvelle api-annuaire est a jour avec l'annuraire public

## Mofification

Rempacement de l'api des etablissement public avec la nouvelle api de l'annuaire public pour récupérer les mails des marie