### PR TITLE
feat: add route admin validate habilitation

### DIFF
--- a/lib/habilitations/__tests__/routes.js
+++ b/lib/habilitations/__tests__/routes.js
@@ -1,3 +1,4 @@
+process.env.ADMIN_TOKEN = 'xxxxxxxxxxxxxxx'
 require('dotenv').config()
 const test = require('ava')
 const express = require('express')
@@ -112,20 +113,59 @@ test.serial('basic habilitation', async t => {
   t.is(res2.body.status, 'accepted')
 })
 
-test.serial('habilitation / client disabled', async t => {
+test.serial('habilitation / validate without token', async t => {
   await mongo.db.collection('clients').insertOne({
     _id: new mongo.ObjectId(),
-    nom: 'ACME disabled',
+    nom: 'ACME 2',
     token: 'foobar',
-    active: false
+    active: true
   })
 
   const server = await getApp()
-  const res = await request(server)
+  const res1 = await request(server)
     .post('/communes/27115/habilitations')
     .set('Authorization', 'Token foobar')
     .set('Content-Type', 'application/json')
-    .expect(403)
+    .expect(201)
 
-  t.is(res.body.message, 'Le client est actuellement désactivé')
+  const habilitationId = res1.body._id
+
+  t.is(res1.body.codeCommune, '27115')
+  t.is(res1.body.emailCommune, 'mairie@breux-sur-avre.fr')
+  t.is(res1.body.status, 'pending')
+  await request(server)
+    .put(`/habilitations/${habilitationId}/validate`)
+    .set('Authorization', 'Token foobar')
+    .set('Content-Type', 'application/json')
+    .expect(401)
+})
+
+test.serial('habilitation / validate', async t => {
+  await mongo.db.collection('clients').insertOne({
+    _id: new mongo.ObjectId(),
+    nom: 'ACME 2',
+    token: 'foobar',
+    active: true
+  })
+
+  const server = await getApp()
+  const res1 = await request(server)
+    .post('/communes/27115/habilitations')
+    .set('Authorization', 'Token foobar')
+    .set('Content-Type', 'application/json')
+    .expect(201)
+
+  const habilitationId = res1.body._id
+
+  t.is(res1.body.codeCommune, '27115')
+  t.is(res1.body.emailCommune, 'mairie@breux-sur-avre.fr')
+  t.is(res1.body.status, 'pending')
+  const res = await request(server)
+    .put(`/habilitations/${habilitationId}/validate`)
+    .set('Authorization', `Token ${process.env.ADMIN_TOKEN}`)
+    .set('Content-Type', 'application/json')
+    .expect(200)
+
+  t.is(res.body.status, 'accepted')
+  t.is(res.body.strategy.type, 'internal')
 })

--- a/lib/habilitations/routes.js
+++ b/lib/habilitations/routes.js
@@ -7,7 +7,7 @@ const {omit} = require('lodash')
 const mongo = require('../util/mongo')
 const errorHandler = require('../util/error-handler')
 const {getCommune} = require('../util/cog')
-const {authClient, ensureCodeCommune, ensureCommuneActuelle} = require('../util/middlewares')
+const {authClient, ensureCodeCommune, ensureCommuneActuelle, ensureIsAdmin} = require('../util/middlewares')
 const w = require('../util/w')
 const {sendMail} = require('../util/sendmail')
 const {createHabilitation, askHabilitation, acceptHabilitation, fetchHabilitation, rejectHabilitation, expandWithClient} = require('./model')
@@ -58,6 +58,13 @@ async function habilitationsRoutes() {
     })
 
     res.status(201).send(habilitation)
+  }))
+
+  app.put('/habilitations/:habilitationId/validate', ensureIsAdmin, w(async (req, res) => {
+    await acceptHabilitation(req.habilitation._id, {strategy: {type: 'internal'}})
+    const habilitation = await fetchHabilitation(req.habilitation._id)
+
+    res.status(200).send(habilitation)
   }))
 
   app.get('/habilitations/:habilitationId', authClient, w(async (req, res) => {


### PR DESCRIPTION
## FONCTIONNALITE

- Ajout d'une route /habiliations/:id/validate (protégé par ensureAdmin) pour valider avec le type `interne` les habilitations