### PR TITLE
fix: make middleware work with all http methods

### DIFF
--- a/src/modules/habilitation/habilitation.module.ts
+++ b/src/modules/habilitation/habilitation.module.ts
@@ -43,13 +43,13 @@ export class HabilitationModule {
       .apply(HabilitationMiddleware)
       .exclude({
         path: 'communes/:codeCommune/habilitations',
-        method: RequestMethod.POST,
+        method: RequestMethod.ALL,
       })
       .forRoutes(HabilitationController);
 
     consumer.apply(CommuneMiddleware).forRoutes({
       path: 'communes/:codeCommune/habilitations',
-      method: RequestMethod.POST,
+      method: RequestMethod.ALL,
     });
   }
 }

--- a/src/modules/revision/revision.module.ts
+++ b/src/modules/revision/revision.module.ts
@@ -48,42 +48,42 @@ export class RevisionModule {
     consumer.apply(RevisionMiddleware).forRoutes(
       {
         path: 'revisions/:revisionId',
-        method: RequestMethod.GET,
+        method: RequestMethod.ALL,
       },
       {
         path: 'revisions/:revisionId/files/bal/download',
-        method: RequestMethod.GET,
+        method: RequestMethod.ALL,
       },
       {
         path: 'revisions/:revisionId/files/bal',
-        method: RequestMethod.PUT,
+        method: RequestMethod.ALL,
       },
       {
         path: 'revisions/:revisionId/compute',
-        method: RequestMethod.POST,
+        method: RequestMethod.ALL,
       },
       {
         path: 'revisions/:revisionId/publish',
-        method: RequestMethod.POST,
+        method: RequestMethod.ALL,
       },
     );
 
     consumer.apply(CommuneMiddleware).forRoutes(
       {
         path: 'communes/:codeCommune/current-revision',
-        method: RequestMethod.GET,
+        method: RequestMethod.ALL,
       },
       {
         path: 'communes/:codeCommune/revisions',
-        method: RequestMethod.GET,
+        method: RequestMethod.ALL,
       },
       {
         path: 'communes/:codeCommune/current-revision/files/bal/download',
-        method: RequestMethod.GET,
+        method: RequestMethod.ALL,
       },
       {
         path: 'communes/:codeCommune/revisions',
-        method: RequestMethod.POST,
+        method: RequestMethod.ALL,
       },
     );
   }

--- a/src/modules/revision/revision.module.ts
+++ b/src/modules/revision/revision.module.ts
@@ -81,10 +81,6 @@ export class RevisionModule {
         path: 'communes/:codeCommune/current-revision/files/bal/download',
         method: RequestMethod.ALL,
       },
-      {
-        path: 'communes/:codeCommune/revisions',
-        method: RequestMethod.ALL,
-      },
     );
   }
 }


### PR DESCRIPTION
Mattermost : https://mattermost.incubateur.net/betagouv/pl/iy7nwfkmo3domc91d4jf41smfy

Problème : Quand on applique un middleware sur une route en particulier, il ne fonctionne qu'avec la méthode http attendue par le controller. Le souci c'est que pour les methodes HEAD et OPTIONS, le middleware ne s'applique pas et le serveur renvoie une 500.
=> Appliquer les middleware pour toutes les méthodes HTTP