### PR TITLE
feat:  add mail in route send code pin

### DIFF
--- a/src/modules/api_annuaire/api_annuaire.spec.ts
+++ b/src/modules/api_annuaire/api_annuaire.spec.ts
@@ -52,8 +52,8 @@ describe('API ANNUAIRE MODULE', () => {
         )
         .reply(200, data);
 
-      const email = await apiAnnuaireService.getEmailCommune(codeCommune);
-      expect(email).toBe('ok@test.fr');
+      const email = await apiAnnuaireService.getEmailsCommune(codeCommune);
+      expect(email).toEqual(['ok@test.fr', 'no@test.fr']);
     });
 
     it('getEmailCommune multi email', async () => {
@@ -74,9 +74,9 @@ describe('API ANNUAIRE MODULE', () => {
         )
         .reply(200, data);
 
-      const email = await apiAnnuaireService.getEmailCommune(codeCommune);
+      const email = await apiAnnuaireService.getEmailsCommune(codeCommune);
 
-      expect(email).toBe('ok@test.fr');
+      expect(email).toEqual(['ok@test.fr', 'wrong@test.fr']);
     });
 
     it('getEmailCommune only mairie deleguee', async () => {
@@ -97,12 +97,12 @@ describe('API ANNUAIRE MODULE', () => {
         )
         .reply(200, data);
 
-      const email = await apiAnnuaireService.getEmailCommune(codeCommune);
+      const email = await apiAnnuaireService.getEmailsCommune(codeCommune);
 
-      expect(email).toBe('ok@ok.fr');
+      expect(email).toEqual(['ok@ok.fr']);
     });
 
-    it('getEmailCommune multi email', async () => {
+    it('getEmailCommune invalid email', async () => {
       const codeCommune = '91400';
 
       // MOCK AXIOS
@@ -120,13 +120,13 @@ describe('API ANNUAIRE MODULE', () => {
         )
         .reply(200, data);
 
-      const email = await apiAnnuaireService.getEmailCommune(codeCommune);
+      const email = await apiAnnuaireService.getEmailsCommune(codeCommune);
       expect(email).toBeUndefined();
     });
 
-    it('getEmailCommune multi email', async () => {
+    it('getEmailCommune no emails', async () => {
       const codeCommune = '91400';
-      const email = await apiAnnuaireService.getEmailCommune(codeCommune);
+      const email = await apiAnnuaireService.getEmailsCommune(codeCommune);
       expect(email).toBeUndefined();
     });
   });

--- a/src/modules/habilitation/dto/send_code_pin.dto.ts
+++ b/src/modules/habilitation/dto/send_code_pin.dto.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail } from 'class-validator';
+
+export class SendCodePinRequestDTO {
+  @IsEmail()
+  @ApiProperty({ type: String, required: true })
+  email: string;
+}

--- a/src/modules/habilitation/habilitation.controller.ts
+++ b/src/modules/habilitation/habilitation.controller.ts
@@ -32,6 +32,7 @@ import {
   FranceConnectCallBackGuard,
 } from './france_connect/france_connect.guard';
 import { HabilitationWithClientDTO } from './dto/habilitation_with_client.dto';
+import { SendCodePinRequestDTO } from './dto/send_code_pin.dto';
 
 @ApiTags('habilitations')
 @Controller('')
@@ -95,11 +96,16 @@ export class HabilitationController {
     operationId: 'sendCodePin',
   })
   @ApiParam({ name: 'habilitationId', required: true, type: String })
+  @ApiBody({ type: SendCodePinRequestDTO, required: true })
   @ApiResponse({ status: HttpStatus.OK })
   @ApiBearerAuth('client-token')
   @UseGuards(ClientGuard)
-  async sendCodePin(@Req() req: CustomRequest, @Res() res: Response) {
-    await this.habilitationService.sendCodePin(req.habilitation);
+  async sendCodePin(
+    @Req() req: CustomRequest,
+    @Body() { email }: SendCodePinRequestDTO,
+    @Res() res: Response,
+  ) {
+    await this.habilitationService.sendCodePin(req.habilitation, email);
     res.sendStatus(HttpStatus.OK);
   }
 

--- a/src/modules/habilitation/habilitation.controller.ts
+++ b/src/modules/habilitation/habilitation.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Get,
   HttpStatus,
+  Param,
   Post,
   Put,
   Req,
@@ -33,11 +34,15 @@ import {
 } from './france_connect/france_connect.guard';
 import { HabilitationWithClientDTO } from './dto/habilitation_with_client.dto';
 import { SendCodePinRequestDTO } from './dto/send_code_pin.dto';
+import { ApiAnnuaireService } from '../api_annuaire/api_annuaire.service';
 
 @ApiTags('habilitations')
 @Controller('')
 export class HabilitationController {
-  constructor(private habilitationService: HabilitationService) {}
+  constructor(
+    private habilitationService: HabilitationService,
+    private apiAnnuaireService: ApiAnnuaireService,
+  ) {}
 
   @Post('communes/:codeCommune/habilitations')
   @ApiOperation({
@@ -54,6 +59,22 @@ export class HabilitationController {
       req.client,
     );
     res.status(HttpStatus.CREATED).json(habilitation);
+  }
+
+  @Get('communes/:codeCommune/emails')
+  @ApiOperation({
+    summary: 'Find many emails commune',
+    operationId: 'findEmailsCommune',
+  })
+  @ApiParam({ name: 'codeCommune', required: true, type: String })
+  @ApiResponse({ status: HttpStatus.OK, type: String, isArray: true })
+  async findEmailsCommune(
+    @Param('codeCommune') codeCommune: string,
+    @Res() res: Response,
+  ) {
+    const emailsCommune =
+      await this.apiAnnuaireService.getEmailsCommune(codeCommune);
+    res.status(HttpStatus.OK).json(emailsCommune);
   }
 
   @Get('habilitations/:habilitationId')

--- a/src/modules/habilitation/habilitation.service.ts
+++ b/src/modules/habilitation/habilitation.service.ts
@@ -163,7 +163,7 @@ export class HabilitationService {
       );
     }
 
-    if (!habilitation.emailCommune) {
+    if (!email) {
       throw new HttpException(
         'Impossible d’envoyer le code, aucun courriel n’est connu pour cette commune',
         HttpStatus.PRECONDITION_FAILED,

--- a/src/modules/habilitation/habilitation.service.ts
+++ b/src/modules/habilitation/habilitation.service.ts
@@ -200,8 +200,8 @@ export class HabilitationService {
       },
     );
 
-    if (habilitation.emailCommune) {
-      const { nom }: CommuneCOG = getCommune(habilitation.codeCommune);
+    if (habilitationUpdated.emailCommune) {
+      const { nom }: CommuneCOG = getCommune(habilitationUpdated.codeCommune);
 
       await this.mailerService.sendMail({
         to: email,

--- a/src/modules/habilitation/habilitation.service.ts
+++ b/src/modules/habilitation/habilitation.service.ts
@@ -145,29 +145,45 @@ export class HabilitationService {
     return expireAt;
   }
 
-  public async sendCodePin(body: Habilitation): Promise<Habilitation> {
-    if (body.status === StatusHabilitationEnum.ACCEPTED) {
+  public async sendCodePin(
+    habilitation: Habilitation,
+    email: string,
+  ): Promise<Habilitation> {
+    if (habilitation.status === StatusHabilitationEnum.ACCEPTED) {
       throw new HttpException(
         'Cette habilitation est déjà validée',
         HttpStatus.PRECONDITION_FAILED,
       );
     }
 
-    if (body.status === StatusHabilitationEnum.REJECTED) {
+    if (habilitation.status === StatusHabilitationEnum.REJECTED) {
       throw new HttpException(
         'Cette habilitation est rejetée',
         HttpStatus.PRECONDITION_FAILED,
       );
     }
 
-    if (!body.emailCommune) {
+    if (!habilitation.emailCommune) {
       throw new HttpException(
         'Impossible d’envoyer le code, aucun courriel n’est connu pour cette commune',
         HttpStatus.PRECONDITION_FAILED,
       );
     }
 
-    if (body.strategy && this.hasBeenSentRecently(body.strategy.createdAt)) {
+    const emailsCommune = await this.apiAnnuaireService.getEmailsCommune(
+      habilitation.codeCommune,
+    );
+    if (!emailsCommune.includes(email)) {
+      throw new HttpException(
+        'Impossible d’envoyer le code, l’email préconisé n’appartient pas à la commune',
+        HttpStatus.PRECONDITION_FAILED,
+      );
+    }
+
+    if (
+      habilitation.strategy &&
+      this.hasBeenSentRecently(habilitation.strategy.createdAt)
+    ) {
       throw new HttpException(
         'Un courriel a déjà été envoyé, merci de patienter',
         HttpStatus.CONFLICT,
@@ -177,21 +193,25 @@ export class HabilitationService {
     const now = new Date();
     const pinCode = await this.generatePinCode();
 
-    const habilitation: Habilitation = await this.updateOne(body.id, {
-      strategy: {
-        type: TypeStrategyEnum.EMAIL,
-        pinCode,
-        pinCodeExpiration: this.getExpirationDate(now),
-        remainingAttempts: 10,
-        createdAt: now,
+    const habilitationUpdated: Habilitation = await this.updateOne(
+      habilitation.id,
+      {
+        emailCommune: email,
+        strategy: {
+          type: TypeStrategyEnum.EMAIL,
+          pinCode,
+          pinCodeExpiration: this.getExpirationDate(now),
+          remainingAttempts: 10,
+          createdAt: now,
+        },
       },
-    });
+    );
 
     const { nom }: CommuneCOG = getCommune(habilitation.codeCommune);
 
     if (habilitation.emailCommune) {
       await this.mailerService.sendMail({
-        to: habilitation.emailCommune,
+        to: email,
         subject: 'Demande de code d’identification',
         template: 'code-pin',
         bcc: this.configService.get('SMTP_BCC'),
@@ -203,7 +223,7 @@ export class HabilitationService {
       });
     }
 
-    return habilitation;
+    return habilitationUpdated;
   }
 
   public async validateCodePin(

--- a/src/modules/habilitation/habilitation.service.ts
+++ b/src/modules/habilitation/habilitation.service.ts
@@ -75,13 +75,10 @@ export class HabilitationService {
   ): Promise<Habilitation> {
     const habilitationId = new ObjectId().toHexString();
 
-    const emailCommune =
-      await this.apiAnnuaireService.getEmailCommune(codeCommune);
-
     const entityToSave: Habilitation = this.habilitationRepository.create({
       id: habilitationId,
       codeCommune,
-      emailCommune,
+      emailCommune: null,
       franceconnectAuthenticationUrl: `${this.configService.get<string>('API_DEPOT_URL')}/habilitations/${habilitationId}/authentication/franceconnect`,
       strategy: null,
       clientId: client.id,

--- a/src/modules/habilitation/habilitation.service.ts
+++ b/src/modules/habilitation/habilitation.service.ts
@@ -163,13 +163,6 @@ export class HabilitationService {
       );
     }
 
-    if (!email) {
-      throw new HttpException(
-        'Impossible d’envoyer le code, aucun courriel n’est connu pour cette commune',
-        HttpStatus.PRECONDITION_FAILED,
-      );
-    }
-
     const emailsCommune = await this.apiAnnuaireService.getEmailsCommune(
       habilitation.codeCommune,
     );
@@ -207,9 +200,9 @@ export class HabilitationService {
       },
     );
 
-    const { nom }: CommuneCOG = getCommune(habilitation.codeCommune);
-
     if (habilitation.emailCommune) {
+      const { nom }: CommuneCOG = getCommune(habilitation.codeCommune);
+
       await this.mailerService.sendMail({
         to: email,
         subject: 'Demande de code d’identification',


### PR DESCRIPTION
## CONTEXT

- Ne plus remplir emailCommune a la création de l'habilitation
- Recevoir le mail du destinataire dans la route `/habilitation/send-code-pin`
- Vérifier que le mail appartient bien a la commune
- Set le communeMail lorsque le mail est envoyé