### PR TITLE
Fufeck feat add query params to commune route to find all commune

### DIFF
--- a/src/lib/class/middlewares/commune.middleware.ts
+++ b/src/lib/class/middlewares/commune.middleware.ts
@@ -12,8 +12,6 @@ import { isCommune, isCommuneAncienne } from '@/lib/utils/cog.utils';
 @Injectable()
 export class CommuneMiddleware implements NestMiddleware {
   async use(req: CustomRequest, res: Response, next: NextFunction) {
-    console.log(req.query);
-
     if (
       (req.query?.allCommunes !== 'true' &&
         !isCommune(req.params.codeCommune)) ||

--- a/src/lib/class/middlewares/commune.middleware.ts
+++ b/src/lib/class/middlewares/commune.middleware.ts
@@ -7,12 +7,20 @@ import {
 import { Response, NextFunction } from 'express';
 
 import { CustomRequest } from '@/lib/types/request.type';
-import { isCommune } from '@/lib/utils/cog.utils';
+import { isCommune, isCommuneAncienne } from '@/lib/utils/cog.utils';
 
 @Injectable()
 export class CommuneMiddleware implements NestMiddleware {
   async use(req: CustomRequest, res: Response, next: NextFunction) {
-    if (!isCommune(req.params.codeCommune)) {
+    console.log(req.query);
+
+    if (
+      (req.query?.allCommunes !== 'true' &&
+        !isCommune(req.params.codeCommune)) ||
+      (req.query?.allCommunes === 'true' &&
+        !isCommune(req.params.codeCommune) &&
+        !isCommuneAncienne(req.params.codeCommune))
+    ) {
       throw new HttpException(
         `Le code commune n’existe pas`,
         HttpStatus.NOT_FOUND,

--- a/src/lib/types/cog.type.ts
+++ b/src/lib/types/cog.type.ts
@@ -12,6 +12,7 @@ export type CommuneCOG = {
   codesPostaux: string[];
   population: number;
   commune?: string;
+  anciensCodes?: string[];
 };
 
 export type DepartementCOG = {

--- a/src/lib/utils/cog.utils.ts
+++ b/src/lib/utils/cog.utils.ts
@@ -1,4 +1,4 @@
-import { keyBy, groupBy } from 'lodash';
+import { keyBy, groupBy, flatten } from 'lodash';
 import * as communes from '@etalab/decoupage-administratif/data/communes.json';
 import * as departements from '@etalab/decoupage-administratif/data/departements.json';
 import * as epci from '@etalab/decoupage-administratif/data/epci.json';
@@ -7,6 +7,13 @@ import { CommuneCOG, DepartementCOG, EpciCOG } from '@/lib/types/cog.type';
 
 const filteredCommunes: CommuneCOG[] = (communes as CommuneCOG[]).filter(
   ({ type }) => ['commune-actuelle', 'arrondissement-municipal'].includes(type),
+);
+
+// CREATE LIST COMMUNES ANCIENNE
+const filteredCommunesAncienne: string[] = flatten(
+  filteredCommunes.map((c) =>
+    c.anciensCodes ? [...c.anciensCodes, c.code] : [],
+  ),
 );
 
 const communesIndex: Record<string, CommuneCOG> = keyBy(
@@ -28,6 +35,10 @@ const communesByDepartementIndex: Record<string, CommuneCOG[]> = groupBy(
 
 export function isCommune(codeCommune: string): boolean {
   return Boolean(communesIndex[codeCommune]);
+}
+
+export function isCommuneAncienne(codeCommune: string): boolean {
+  return filteredCommunesAncienne.includes(codeCommune);
 }
 
 export function getCommune(codeCommune: string): CommuneCOG {

--- a/src/modules/habilitation/habilitation.controller.ts
+++ b/src/modules/habilitation/habilitation.controller.ts
@@ -16,6 +16,7 @@ import {
   ApiExcludeEndpoint,
   ApiOperation,
   ApiParam,
+  ApiQuery,
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
@@ -35,6 +36,7 @@ import {
 import { HabilitationWithClientDTO } from './dto/habilitation_with_client.dto';
 import { SendCodePinRequestDTO } from './dto/send_code_pin.dto';
 import { ApiAnnuaireService } from '../api_annuaire/api_annuaire.service';
+import { AnciennesCommunesDTO } from '../revision/dto/ancienne_commune.dto';
 
 @ApiTags('habilitations')
 @Controller('')
@@ -67,6 +69,7 @@ export class HabilitationController {
     operationId: 'findEmailsCommune',
   })
   @ApiParam({ name: 'codeCommune', required: true, type: String })
+  @ApiQuery({ type: AnciennesCommunesDTO })
   @ApiResponse({ status: HttpStatus.OK, type: String, isArray: true })
   async findEmailsCommune(
     @Param('codeCommune') codeCommune: string,

--- a/src/modules/revision/dto/ancienne_commune.dto.ts
+++ b/src/modules/revision/dto/ancienne_commune.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsOptional } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+export class AnciennesCommunesDTO {
+  @IsOptional()
+  @IsBoolean()
+  @Transform(({ value }) => value === 'true' || value === true)
+  @ApiProperty({
+    type: Boolean,
+    required: null,
+    description:
+      'Indique si on souhaite récupérer les révisions de toutes les communes',
+    default: false,
+  })
+  allCommunes?: boolean;
+}

--- a/src/modules/revision/dto/status_revisions.dto.ts
+++ b/src/modules/revision/dto/status_revisions.dto.ts
@@ -1,0 +1,26 @@
+import { ApiProperty, IntersectionType } from '@nestjs/swagger';
+import { IsEnum, IsOptional } from 'class-validator';
+import { StatusRevisionEnum } from '../revision.entity';
+import { AnciennesCommunesDTO } from './ancienne_commune.dto';
+
+export const StatusSearchEnum = {
+  ...StatusRevisionEnum,
+  ALL: 'all',
+};
+
+export class StatusRevisionsDTO {
+  @IsOptional()
+  @IsEnum(StatusSearchEnum)
+  @ApiProperty({
+    enum: StatusSearchEnum,
+    required: false,
+    description:
+      'Filtre les révisions par statut, par défaut les révisions publiées',
+  })
+  status?: StatusRevisionEnum | 'all';
+}
+
+export class RevisionQueryDto extends IntersectionType(
+  StatusRevisionsDTO,
+  AnciennesCommunesDTO,
+) {}


### PR DESCRIPTION
## FONCTIONNALITE

Ajouter un query params sur les route qui utilise le CommuneMiddelware pour préciser si la commune peut être ancienne ou non.

Le but de ce query params est de ne pas changer la requête de base mais de pouvoir récupérer les révisions sur bal-admin (avec un paramètre en plus)