### PR TITLE
feat: add query params codeCommune to route /current-revision

### DIFF
--- a/src/lib/class/pipes/validation_cog.pipe.ts
+++ b/src/lib/class/pipes/validation_cog.pipe.ts
@@ -1,0 +1,14 @@
+import { isCommune } from '@/lib/utils/cog.utils';
+import { PipeTransform, Injectable, BadRequestException } from '@nestjs/common';
+
+@Injectable()
+export class ValidationCogPipe implements PipeTransform {
+  transform(value: string[]) {
+    for (const codeCommune of value) {
+      if (!isCommune(codeCommune)) {
+        throw new BadRequestException(`Code commune ${codeCommune} invalide`);
+      }
+    }
+    return value;
+  }
+}

--- a/src/lib/class/pipes/validation_cog.pipe.ts
+++ b/src/lib/class/pipes/validation_cog.pipe.ts
@@ -4,9 +4,11 @@ import { PipeTransform, Injectable, BadRequestException } from '@nestjs/common';
 @Injectable()
 export class ValidationCogPipe implements PipeTransform {
   transform(value: string[]) {
-    for (const codeCommune of value) {
-      if (!isCommune(codeCommune)) {
-        throw new BadRequestException(`Code commune ${codeCommune} invalide`);
+    if (value) {
+      for (const codeCommune of value) {
+        if (!isCommune(codeCommune)) {
+          throw new BadRequestException(`Code commune ${codeCommune} invalide`);
+        }
       }
     }
     return value;

--- a/src/modules/revision/revision.controller.ts
+++ b/src/modules/revision/revision.controller.ts
@@ -3,6 +3,7 @@ import {
   Get,
   HttpException,
   HttpStatus,
+  ParseArrayPipe,
   Query,
   Req,
   Res,
@@ -25,7 +26,7 @@ import { RevisionService } from './revision.service';
 import { RevisionWithClientDTO } from './dto/revision_with_client.dto';
 import { RevisionQueryDto } from './dto/status_revisions.dto';
 import { AnciennesCommunesDTO } from './dto/ancienne_commune.dto';
-
+import { ValidationCogPipe } from '@/lib/class/pipes/validation_cog.pipe';
 @ApiTags('revisions')
 @Controller('')
 export class RevisionController {
@@ -40,14 +41,25 @@ export class RevisionController {
     operationId: 'findCurrent',
   })
   @ApiQuery({ name: 'publishedSince', required: false, type: Date })
+  @ApiQuery({
+    name: 'codesCommune',
+    required: false,
+    type: String,
+    isArray: true,
+  })
   @ApiResponse({ status: HttpStatus.OK, type: RevisionWithClientDTO })
   async findCurrents(
     @Query('publishedSince', ParseDatePipe)
     publishedSince: Date,
-    @Res() res: Response,
+    @Query('codesCommune', ParseArrayPipe, ValidationCogPipe)
+    codesCommune: string[],
+    @Res()
+    res: Response,
   ) {
-    const revisions: Revision[] =
-      await this.revisionService.findCurrents(publishedSince);
+    const revisions: Revision[] = await this.revisionService.findCurrents(
+      publishedSince,
+      codesCommune,
+    );
     const revisionsWithClients: RevisionWithClientDTO[] =
       await this.revisionService.expandsWithClients(revisions);
     res.status(HttpStatus.OK).json(revisionsWithClients);

--- a/src/modules/revision/revision.controller.ts
+++ b/src/modules/revision/revision.controller.ts
@@ -51,7 +51,11 @@ export class RevisionController {
   async findCurrents(
     @Query('publishedSince', ParseDatePipe)
     publishedSince: Date,
-    @Query('codesCommune', ParseArrayPipe, ValidationCogPipe)
+    @Query(
+      'codesCommune',
+      new ParseArrayPipe({ optional: true }),
+      ValidationCogPipe,
+    )
     codesCommune: string[],
     @Res()
     res: Response,

--- a/src/modules/revision/revision.controller.ts
+++ b/src/modules/revision/revision.controller.ts
@@ -42,7 +42,7 @@ export class RevisionController {
   })
   @ApiQuery({ name: 'publishedSince', required: false, type: Date })
   @ApiQuery({
-    name: 'codesCommune',
+    name: 'codesCommunes',
     required: false,
     type: String,
     isArray: true,
@@ -52,17 +52,17 @@ export class RevisionController {
     @Query('publishedSince', ParseDatePipe)
     publishedSince: Date,
     @Query(
-      'codesCommune',
+      'codesCommunes',
       new ParseArrayPipe({ optional: true }),
       ValidationCogPipe,
     )
-    codesCommune: string[],
+    codesCommunes: string[],
     @Res()
     res: Response,
   ) {
     const revisions: Revision[] = await this.revisionService.findCurrents(
       publishedSince,
-      codesCommune,
+      codesCommunes,
     );
     const revisionsWithClients: RevisionWithClientDTO[] =
       await this.revisionService.expandsWithClients(revisions);

--- a/src/modules/revision/revision.service.ts
+++ b/src/modules/revision/revision.service.ts
@@ -119,14 +119,14 @@ export class RevisionService {
 
   public async findCurrents(
     publishedSince: Date | null = null,
-    codesCommune: string[] | null = null,
+    codesCommunes: string[] | null = null,
   ) {
     const publishedSinceQuery = publishedSince
       ? { publishedAt: MoreThan(publishedSince) }
       : {};
 
-    const codesCommuneQuery = codesCommune
-      ? { codeCommune: In(codesCommune) }
+    const codesCommuneQuery = codesCommunes
+      ? { codeCommune: In(codesCommunes) }
       : {};
 
     const revisions: Revision[] = await this.revisionRepository.find({

--- a/src/modules/revision/revision.service.ts
+++ b/src/modules/revision/revision.service.ts
@@ -22,6 +22,7 @@ import { AuthorizationStrategyEnum, Client } from '../client/client.entity';
 import {
   FindOptionsSelect,
   FindOptionsWhere,
+  In,
   MoreThan,
   Not,
   Repository,
@@ -116,13 +117,24 @@ export class RevisionService {
     return query.getRawMany();
   }
 
-  public async findCurrents(publishedSince: Date | null = null) {
+  public async findCurrents(
+    publishedSince: Date | null = null,
+    codesCommune: string[] = [],
+  ) {
     const publishedSinceQuery = publishedSince
       ? { publishedAt: MoreThan(publishedSince) }
       : {};
 
+    const codesCommuneQuery = codesCommune
+      ? { codeCommune: In(codesCommune) }
+      : {};
+
     const revisions: Revision[] = await this.revisionRepository.find({
-      where: { isCurrent: true, ...publishedSinceQuery },
+      where: {
+        isCurrent: true,
+        ...publishedSinceQuery,
+        ...codesCommuneQuery,
+      },
       select: {
         id: true,
         codeCommune: true,

--- a/src/modules/revision/revision.service.ts
+++ b/src/modules/revision/revision.service.ts
@@ -119,7 +119,7 @@ export class RevisionService {
 
   public async findCurrents(
     publishedSince: Date | null = null,
-    codesCommune: string[] = [],
+    codesCommune: string[] | null = null,
   ) {
     const publishedSinceQuery = publishedSince
       ? { publishedAt: MoreThan(publishedSince) }

--- a/src/modules/revision/revision.spec.ts
+++ b/src/modules/revision/revision.spec.ts
@@ -257,6 +257,40 @@ describe('REVISION MODULE', () => {
     });
   });
 
+  it('GET /current-revisions codesCommunes', async () => {
+    const client: Client2 = await createClient();
+
+    await createRevision({
+      codeCommune: '91534',
+      clientId: client.id,
+      status: StatusRevisionEnum.PUBLISHED,
+      isCurrent: true,
+      publishedAt: sub(new Date(), { years: 1 }),
+    });
+
+    await createRevision({
+      codeCommune: '43089',
+      clientId: client.id,
+      status: StatusRevisionEnum.PUBLISHED,
+      isCurrent: true,
+      publishedAt: sub(new Date(), { weeks: 1 }),
+    });
+
+    await createRevision({
+      codeCommune: '43001',
+      clientId: client.id,
+      status: StatusRevisionEnum.PUBLISHED,
+      isCurrent: true,
+      publishedAt: sub(new Date(), { weeks: 1 }),
+    });
+
+    const { body } = await request(app.getHttpServer())
+      .get(`/current-revisions?codesCommunes=91534&codesCommunes=43089`)
+      .expect(200);
+
+    expect(body.length).toBe(2);
+  });
+
   describe('GET /communes/:codeCommune/current-revision', () => {
     it('GET /communes/:codeCommune/current-revision NOT EXIST', async () => {
       await request(app.getHttpServer())


### PR DESCRIPTION
## FONCTIONNALITE

- AJout d'un query params sur la route /current-revisions pour récupérer seulement certaine commune si on ne veut pas les révision courante des 36000 communes