### PR TITLE
feat: block compute revision when 80 percentage adresses deleted

### DIFF
--- a/src/modules/ban/ban.service.ts
+++ b/src/modules/ban/ban.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { AxiosError } from 'axios';
 import { catchError, firstValueFrom } from 'rxjs';
+import { LookupResponse } from './ban.type';
 
 @Injectable()
 export class BanService {
@@ -10,24 +11,20 @@ export class BanService {
     private readonly logger: Logger,
   ) {}
 
-  public async getBanAssemblage(codeCommune: string): Promise<Buffer> {
+  public async getLookup(codeCommune: string): Promise<LookupResponse> {
     const { data } = await firstValueFrom(
-      await this.httpService
-        .get<Buffer>(`/communes/${codeCommune}/download/csv-bal/adresses`, {
-          responseType: 'arraybuffer',
-        })
-        .pipe(
-          catchError((error: AxiosError) => {
-            throw error;
-          }),
-        ),
+      await this.httpService.get<LookupResponse>(`/lookup/${codeCommune}`).pipe(
+        catchError((error: AxiosError) => {
+          throw error;
+        }),
+      ),
     );
     return data;
   }
 
   public async composeCommune(codeCommune: string) {
     try {
-      const url: string = `/communes/${codeCommune}/compose`;
+      const url: string = `/ban/communes/${codeCommune}/compose`;
       await firstValueFrom(
         this.httpService.post<any>(url).pipe(
           catchError((error: AxiosError) => {

--- a/src/modules/ban/ban.type.ts
+++ b/src/modules/ban/ban.type.ts
@@ -1,0 +1,41 @@
+export interface LookupResponse {
+  id: string;
+  type: string;
+  codeCommune: string;
+  banId: string;
+  nomCommune: string;
+  departement: {
+    nom: string;
+    code: string;
+  };
+  region: {
+    nom: string;
+    code: string;
+  };
+  codesPostaux: string[];
+  population: number;
+  typeCommune: string; // ex: "commune-actuelle"
+  nbNumeros: number;
+  nbNumerosCertifies: number;
+  nbVoies: number;
+  nbLieuxDits: number;
+  typeComposition: string; // ex: "bal"
+  displayBBox: [number, number, number, number];
+  idRevision: string;
+  dateRevision: string; // ISO date string
+  withBanId: boolean;
+  voies: Voie[];
+}
+
+export interface Voie {
+  id: string;
+  type: 'voie';
+  banId: string;
+  idVoie: string;
+  nomVoie: string;
+  nomVoieAlt: Record<string, string>; // objet vide ou dictionnaire de traductions/alternatifs
+  sourceNomVoie: string;
+  sources: string[];
+  nbNumeros: number;
+  nbNumerosCertifies: number;
+}


### PR DESCRIPTION
## CONTEXT

Il y a de temps en temps des communes qui font de grosse bourdes et supprime un grand nombre d'adresses sans faire exprès.

## FONCTIONNALITE

On bloque les révisions ou il y a un déficit d'adresses de plus de 80% avec une erreur dans la route `/compute`