### PR TITLE
migration: habilitaiton no expire

### DIFF
--- a/migrations/1758030071123-habilitation_no_expire.ts
+++ b/migrations/1758030071123-habilitation_no_expire.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class HabilitationNoExpire1758030071123 implements MigrationInterface {
+  name = 'HabilitationNoExpire1758030071123';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "habilitations" DROP COLUMN "expires_at"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "habilitations" ADD "expires_at" TIMESTAMP`,
+    );
+  }
+}


### PR DESCRIPTION
## CONTEXT

Pour rollback (au cas ou) la suppresion de l'expiration de l'habilitation, nous n'avons pas mis la migration avec la PR
Passer la migration dans quelques semaines lorsque nous sommes sur que cela n'a engendré aucun bug et qu'on ne rollback pas