### PR TITLE
feat: route revision sync and publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "cpu-features": "npm:noop3@13.8.1"
   },
   "dependencies": {
+    "formatting-bal": "file:../formatting-bal",
     "@aws-sdk/client-s3": "^3.576.0",
     "@ban-team/validateur-bal": "^3.5.2",
     "@etalab/decoupage-administratif": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "cpu-features": "npm:noop3@13.8.1"
   },
   "dependencies": {
-    "formatting-bal": "file:../formatting-bal",
+    "@ban-team/formatter-bal": "^0.1.1",
     "@aws-sdk/client-s3": "^3.576.0",
     "@ban-team/validateur-bal": "^3.5.2",
     "@etalab/decoupage-administratif": "^6.0.0",

--- a/src/modules/revision/mock/1.3-no-ids.csv
+++ b/src/modules/revision/mock/1.3-no-ids.csv
@@ -1,0 +1,2 @@
+cle_interop;commune_insee;voie_nom;numero;suffixe;commune_nom;position;long;lat;x;y;source;date_der_maj
+31591_xxxx_00009;31591;Rue des 3 Places;9;;Escoulis;entrée;1.028392;43.111637;539416.13;6225601.11;;2020-11-09

--- a/src/modules/revision/mock/1.3-with-ids.csv
+++ b/src/modules/revision/mock/1.3-with-ids.csv
@@ -1,0 +1,2 @@
+cle_interop;uid_adresse;commune_insee;voie_nom;numero;suffixe;commune_nom;position;long;lat;x;y;source;date_der_maj
+31591_xxxx_00009;@c:11111111-1111-4111-8111-111111111111 @v:22222222-2222-4222-8222-222222222222 @a:33333333-3333-4333-8333-333333333333;31591;Rue des 3 Places;9;;Escoulis;entrée;1.028392;43.111637;539416.13;6225601.11;;2020-11-09

--- a/src/modules/revision/mock/1.4-with-ids.csv
+++ b/src/modules/revision/mock/1.4-with-ids.csv
@@ -1,0 +1,2 @@
+cle_interop;id_ban_commune;id_ban_toponyme;id_ban_adresse;commune_insee;voie_nom;numero;suffixe;commune_nom;position;long;lat;x;y;source;date_der_maj
+31591_xxxx_00009;11111111-1111-4111-8111-111111111111;22222222-2222-4222-8222-222222222222;33333333-3333-4333-8333-333333333333;31591;Rue des 3 Places;9;;Escoulis;entrée;1.028392;43.111637;539416.13;6225601.11;;2020-11-09

--- a/src/modules/revision/mock/1.5-with-ids.csv
+++ b/src/modules/revision/mock/1.5-with-ids.csv
@@ -1,0 +1,2 @@
+cle_interop;id_ban_commune;id_ban_toponyme;id_ban_adresse;commune_insee;toponyme;numero;suffixe;commune_nom;position;long;lat;x;y;source;date_der_maj
+31591_xxxx_00009;11111111-1111-4111-8111-111111111111;22222222-2222-4222-8222-222222222222;33333333-3333-4333-8333-333333333333;31591;Rue des 3 Places;9;;Escoulis;entrée;1.028392;43.111637;539416.13;6225601.11;;2020-11-09

--- a/src/modules/revision/mock/ban-reference.csv
+++ b/src/modules/revision/mock/ban-reference.csv
@@ -1,0 +1,2 @@
+cle_interop;id_ban_commune;id_ban_toponyme;id_ban_adresse;commune_insee;voie_nom;numero;suffixe;commune_nom;position;long;lat;x;y;source;date_der_maj
+31591_xxxx_00009;44444444-4444-4444-8444-444444444444;55555555-5555-4555-8555-555555555555;66666666-6666-4666-8666-666666666666;31591;Rue des 3 Places;9;;Escoulis;entrée;1.028392;43.111637;539416.13;6225601.11;;2020-11-09

--- a/src/modules/revision/publication.controller.ts
+++ b/src/modules/revision/publication.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  HttpException,
   HttpStatus,
   Logger,
   Post,
@@ -33,11 +34,14 @@ import { FileBinary } from '@/lib/class/decorators/file_binary.decorator';
 import { FileBinaryPipe } from '@/lib/class/pipes/file_binary.pipe';
 import { FileBinaryInterceptor } from '@/lib/class/interceptors/file_binary.interceptor';
 import { PublishDTO } from './dto/publish.dto';
+import { AdminGuard } from '@/lib/class/guards/admin.guard';
+import { ClientService } from '../client/client.service';
 
 @ApiTags('publications')
 @Controller('')
 export class PublicationController {
   constructor(
+    private clientService: ClientService,
     private revisionService: RevisionService,
     private readonly logger: Logger,
   ) {}
@@ -190,5 +194,53 @@ export class PublicationController {
     const revisionWithClient: RevisionWithClientDTO =
       await this.revisionService.expandWithClientAndFile(revision);
     res.status(HttpStatus.OK).json(revisionWithClient);
+  }
+
+  @Post('revisions/:revisionId/sync-ids-ban-publish')
+  @ApiParam({ name: 'revisionId', required: true, type: String })
+  @ApiOperation({
+    summary: 'Synchro ids BAL with ids BAN and publish',
+    operationId: 'syncIdsBANPublish',
+  })
+  @ApiBearerAuth('admin-token')
+  @UseGuards(AdminGuard)
+  @ApiResponse({
+    status: HttpStatus.OK,
+    type: Revision,
+  })
+  async syncIdsBANPublish(@Req() req: CustomRequest, @Res() res: Response) {
+    try {
+      if (!req.revision.isCurrent) {
+        throw new HttpException(
+          'Erreur: on ne peut pas synchroniser une publication non courante',
+          HttpStatus.INTERNAL_SERVER_ERROR,
+        );
+      }
+      const { file: csvFileSync, codeCommune } =
+        await this.revisionService.syncIdsBAN(req.revision);
+
+      const client = await this.clientService.findOneOrFail(
+        req.revision.clientId,
+      );
+      const newRevisionFirstStep: Revision =
+        await this.revisionService.createOne(codeCommune, client, {
+          ...req.revision.context,
+          extras: {
+            ...req.revision.context?.extras,
+            syncRevisionId: req.revision.id,
+          },
+        });
+      await this.revisionService.setFile(newRevisionFirstStep, csvFileSync);
+      const newRevisionSecondStep: Revision =
+        await this.revisionService.computeOne(newRevisionFirstStep, client);
+      const newRevisionFinalStep: Revision =
+        await this.revisionService.publishOneWithLock(
+          newRevisionSecondStep,
+          client,
+        );
+      res.status(HttpStatus.OK).send(newRevisionFinalStep);
+    } catch (error) {
+      throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
   }
 }

--- a/src/modules/revision/revision.controller.ts
+++ b/src/modules/revision/revision.controller.ts
@@ -4,11 +4,14 @@ import {
   HttpException,
   HttpStatus,
   ParseArrayPipe,
+  Post,
   Query,
   Req,
   Res,
+  UseGuards,
 } from '@nestjs/common';
 import {
+  ApiBearerAuth,
   ApiOperation,
   ApiParam,
   ApiQuery,
@@ -27,6 +30,9 @@ import { RevisionWithClientDTO } from './dto/revision_with_client.dto';
 import { RevisionQueryDto } from './dto/status_revisions.dto';
 import { AnciennesCommunesDTO } from './dto/ancienne_commune.dto';
 import { ValidationCogPipe } from '@/lib/class/pipes/validation_cog.pipe';
+import { AdminGuard } from '@/lib/class/guards/admin.guard';
+import { ClientService } from '../client/client.service';
+import { ConfigService } from '@nestjs/config';
 
 @ApiTags('revisions')
 @Controller('')
@@ -34,6 +40,8 @@ export class RevisionController {
   constructor(
     private revisionService: RevisionService,
     private fileService: FileService,
+    private clientService: ClientService,
+    private configService: ConfigService,
   ) {}
 
   @Get('current-revisions')
@@ -216,5 +224,50 @@ export class RevisionController {
     res.attachment(`bal-${req.revision.codeCommune}.csv`);
     res.setHeader('Content-Type', 'text/csv');
     res.send(data);
+  }
+
+  @Post('revisions/:revisionId/sync-ids-ban-publish')
+  @ApiParam({ name: 'revisionId', required: true, type: String })
+  @ApiOperation({
+    summary: 'Synchro ids BAL with ids BAN and publish',
+    operationId: 'syncIdsBANPublish',
+  })
+  @ApiBearerAuth('admin-token')
+  @UseGuards(AdminGuard)
+  @ApiResponse({
+    status: HttpStatus.OK,
+    type: Revision,
+  })
+  async syncIdsBANPublish(@Req() req: CustomRequest, @Res() res: Response) {
+    try {
+      const { file: csvFileSync, codeCommune } =
+        await this.revisionService.syncIdsBAN(req.revision);
+
+      const clienBalAdmin = await this.clientService.findOneOrFail(
+        this.configService.get('ID_CLIENT_BAL_ADMIN'),
+      );
+      const newRevisionFirstStep: Revision =
+        await this.revisionService.createOne(codeCommune, clienBalAdmin, {
+          nomComplet: 'ANCT',
+          organisation: 'ANCT',
+          extras: {
+            sourceRevisionId: req.revision.id,
+          },
+        });
+      await this.revisionService.setFile(newRevisionFirstStep, csvFileSync);
+      const newRevisionSecondStep: Revision =
+        await this.revisionService.computeOne(
+          newRevisionFirstStep,
+          clienBalAdmin,
+        );
+      const newRevisionFinalStep: Revision =
+        await this.revisionService.publishOneWithLock(
+          newRevisionSecondStep,
+          clienBalAdmin,
+        );
+      res.status(HttpStatus.OK).send(newRevisionFinalStep);
+    } catch (error) {
+      throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
   }
 }

--- a/src/modules/revision/revision.controller.ts
+++ b/src/modules/revision/revision.controller.ts
@@ -243,27 +243,24 @@ export class RevisionController {
       const { file: csvFileSync, codeCommune } =
         await this.revisionService.syncIdsBAN(req.revision);
 
-      const clienBalAdmin = await this.clientService.findOneOrFail(
-        this.configService.get('ID_CLIENT_BAL_ADMIN'),
+      const client = await this.clientService.findOneOrFail(
+        req.revision.clientId,
       );
       const newRevisionFirstStep: Revision =
-        await this.revisionService.createOne(codeCommune, clienBalAdmin, {
-          nomComplet: 'ANCT',
-          organisation: 'ANCT',
+        await this.revisionService.createOne(codeCommune, client, {
+          ...req.revision.context,
           extras: {
-            sourceRevisionId: req.revision.id,
+            ...req.revision.context?.extras,
+            syncRevisionId: req.revision.id,
           },
         });
       await this.revisionService.setFile(newRevisionFirstStep, csvFileSync);
       const newRevisionSecondStep: Revision =
-        await this.revisionService.computeOne(
-          newRevisionFirstStep,
-          clienBalAdmin,
-        );
+        await this.revisionService.computeOne(newRevisionFirstStep, client);
       const newRevisionFinalStep: Revision =
         await this.revisionService.publishOneWithLock(
           newRevisionSecondStep,
-          clienBalAdmin,
+          client,
         );
       res.status(HttpStatus.OK).send(newRevisionFinalStep);
     } catch (error) {

--- a/src/modules/revision/revision.controller.ts
+++ b/src/modules/revision/revision.controller.ts
@@ -4,14 +4,11 @@ import {
   HttpException,
   HttpStatus,
   ParseArrayPipe,
-  Post,
   Query,
   Req,
   Res,
-  UseGuards,
 } from '@nestjs/common';
 import {
-  ApiBearerAuth,
   ApiOperation,
   ApiParam,
   ApiQuery,
@@ -30,9 +27,6 @@ import { RevisionWithClientDTO } from './dto/revision_with_client.dto';
 import { RevisionQueryDto } from './dto/status_revisions.dto';
 import { AnciennesCommunesDTO } from './dto/ancienne_commune.dto';
 import { ValidationCogPipe } from '@/lib/class/pipes/validation_cog.pipe';
-import { AdminGuard } from '@/lib/class/guards/admin.guard';
-import { ClientService } from '../client/client.service';
-import { ConfigService } from '@nestjs/config';
 
 @ApiTags('revisions')
 @Controller('')
@@ -40,8 +34,6 @@ export class RevisionController {
   constructor(
     private revisionService: RevisionService,
     private fileService: FileService,
-    private clientService: ClientService,
-    private configService: ConfigService,
   ) {}
 
   @Get('current-revisions')
@@ -217,47 +209,5 @@ export class RevisionController {
     res.attachment(`bal-${req.revision.codeCommune}.csv`);
     res.setHeader('Content-Type', 'text/csv');
     res.send(data);
-  }
-
-  @Post('revisions/:revisionId/sync-ids-ban-publish')
-  @ApiParam({ name: 'revisionId', required: true, type: String })
-  @ApiOperation({
-    summary: 'Synchro ids BAL with ids BAN and publish',
-    operationId: 'syncIdsBANPublish',
-  })
-  @ApiBearerAuth('admin-token')
-  @UseGuards(AdminGuard)
-  @ApiResponse({
-    status: HttpStatus.OK,
-    type: Revision,
-  })
-  async syncIdsBANPublish(@Req() req: CustomRequest, @Res() res: Response) {
-    try {
-      const { file: csvFileSync, codeCommune } =
-        await this.revisionService.syncIdsBAN(req.revision);
-
-      const client = await this.clientService.findOneOrFail(
-        req.revision.clientId,
-      );
-      const newRevisionFirstStep: Revision =
-        await this.revisionService.createOne(codeCommune, client, {
-          ...req.revision.context,
-          extras: {
-            ...req.revision.context?.extras,
-            syncRevisionId: req.revision.id,
-          },
-        });
-      await this.revisionService.setFile(newRevisionFirstStep, csvFileSync);
-      const newRevisionSecondStep: Revision =
-        await this.revisionService.computeOne(newRevisionFirstStep, client);
-      const newRevisionFinalStep: Revision =
-        await this.revisionService.publishOneWithLock(
-          newRevisionSecondStep,
-          client,
-        );
-      res.status(HttpStatus.OK).send(newRevisionFinalStep);
-    } catch (error) {
-      throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
-    }
   }
 }

--- a/src/modules/revision/revision.module.ts
+++ b/src/modules/revision/revision.module.ts
@@ -69,6 +69,10 @@ export class RevisionModule {
         path: 'revisions/:revisionId/publish',
         method: RequestMethod.ALL,
       },
+      {
+        path: 'revisions/:revisionId/sync-ids-ban-publish',
+        method: RequestMethod.ALL,
+      },
     );
 
     consumer.apply(CommuneMiddleware).forRoutes(

--- a/src/modules/revision/revision.service.ts
+++ b/src/modules/revision/revision.service.ts
@@ -12,6 +12,7 @@ import { StatusHabilitationEnum } from '@/modules/habilitation/habilitation.enti
 import { RevisionWithClientDTO } from './dto/revision_with_client.dto';
 import { ValidationService } from './validation.service';
 import { NotifyService } from './notify.service';
+import { BalTree, formattingBAL } from 'formatting-bal';
 import {
   Context,
   Revision,
@@ -444,5 +445,19 @@ export class RevisionService {
     await this.notifyService.onForcePublish(prevRevision, revisionPublished);
 
     return revisionPublished;
+  }
+
+  async syncIdsBAN(revision: Revision): Promise<{
+    codeCommune: string;
+    file: Buffer;
+  }> {
+    const csvFile = await this.fileService.findDataByRevision(revision.id);
+    const { file, tree } = (await formattingBAL(csvFile, {
+      withTree: true,
+    })) as {
+      tree: BalTree;
+      file: Buffer;
+    };
+    return { file, codeCommune: tree.commune_insee };
   }
 }

--- a/src/modules/revision/revision.service.ts
+++ b/src/modules/revision/revision.service.ts
@@ -12,7 +12,7 @@ import { StatusHabilitationEnum } from '@/modules/habilitation/habilitation.enti
 import { RevisionWithClientDTO } from './dto/revision_with_client.dto';
 import { ValidationService } from './validation.service';
 import { NotifyService } from './notify.service';
-import { BalTree, formattingBAL } from 'formatting-bal';
+import { BalTree, formatterBAL } from '@ban-team/formatter-bal';
 import {
   Context,
   Revision,
@@ -452,7 +452,7 @@ export class RevisionService {
     file: Buffer;
   }> {
     const csvFile = await this.fileService.findDataByRevision(revision.id);
-    const { file, tree } = (await formattingBAL(csvFile, {
+    const { file, tree } = (await formatterBAL(csvFile, {
       withTree: true,
     })) as {
       tree: BalTree;

--- a/src/modules/revision/sync-and-publish.spec.ts
+++ b/src/modules/revision/sync-and-publish.spec.ts
@@ -1,0 +1,465 @@
+import {
+  PostgreSqlContainer,
+  StartedPostgreSqlContainer,
+} from '@testcontainers/postgresql';
+import { Client } from 'pg';
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  Global,
+  INestApplication,
+  Module,
+  ValidationPipe,
+} from '@nestjs/common';
+import * as request from 'supertest';
+import * as fs from 'fs';
+import * as https from 'https';
+import { Readable } from 'stream';
+import { join } from 'path';
+import * as Papa from 'papaparse';
+
+import {
+  AuthorizationStrategyEnum,
+  Client as Client2,
+} from '../client/client.entity';
+import { Mandataire } from '../mandataire/mandataire.entity';
+import { ChefDeFile } from '../chef_de_file/chef_de_file.entity';
+import { RevisionModule } from './revision.module';
+import { Revision, StatusRevisionEnum } from './revision.entity';
+import { S3Service } from '../file/s3.service';
+import { File } from '../file/file.entity';
+import { Habilitation } from '../habilitation/habilitation.entity';
+import { Perimeter } from '../chef_de_file/perimeters.entity';
+import { getRepositoryToken, TypeOrmModule } from '@nestjs/typeorm';
+import { ObjectId } from 'bson';
+import { Repository } from 'typeorm';
+import { MailerService } from '@nestjs-modules/mailer';
+import { generateToken } from '@/lib/utils/token.utils';
+
+process.env.FC_FS_ID = 'coucou';
+process.env.ADMIN_TOKEN = 'xxxx';
+process.env.BAN_API_URL = 'https://plateforme.adresse.data.gouv.fr';
+
+// IDs dans les fichiers BAL source (anciens IDs) — UUID v4 valides
+const OLD_COMMUNE_ID = '11111111-1111-4111-8111-111111111111';
+const OLD_TOPONYME_ID = '22222222-2222-4222-8222-222222222222';
+const OLD_ADRESSE_ID = '33333333-3333-4333-8333-333333333333';
+
+// IDs attendus dans le fichier produit (venant de la BAN) — UUID v4 valides
+const BAN_COMMUNE_ID = '44444444-4444-4444-8444-444444444444';
+const BAN_TOPONYME_ID = '55555555-5555-4555-8555-555555555555';
+const BAN_ADRESSE_ID = '66666666-6666-4666-8666-666666666666';
+
+@Global()
+@Module({
+  providers: [
+    {
+      provide: MailerService,
+      useValue: {
+        sendMail: jest.fn(),
+      },
+    },
+  ],
+  exports: [MailerService],
+})
+class MailerModule {}
+
+describe('SYNC AND PUBLISH MODULE', () => {
+  let app: INestApplication;
+  let postgresContainer: StartedPostgreSqlContainer;
+  let postgresClient: Client;
+  let mandataireRepository: Repository<Mandataire>;
+  let clientRepository: Repository<Client2>;
+  let chefDeFileRepository: Repository<ChefDeFile>;
+  let habilitationRepository: Repository<Habilitation>;
+  let revisionRepository: Repository<Revision>;
+  let fileRepository: Repository<File>;
+  let s3Service: S3Service;
+
+  const banReferenceCsv = fs.readFileSync(
+    join(__dirname, 'mock', 'ban-reference.csv'),
+  );
+
+  beforeAll(async () => {
+    postgresContainer = await new PostgreSqlContainer().start();
+    postgresClient = new Client({
+      host: postgresContainer.getHost(),
+      port: postgresContainer.getPort(),
+      database: postgresContainer.getDatabase(),
+      user: postgresContainer.getUsername(),
+      password: postgresContainer.getPassword(),
+    });
+    await postgresClient.connect();
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'postgres',
+          host: postgresContainer.getHost(),
+          port: postgresContainer.getPort(),
+          username: postgresContainer.getUsername(),
+          password: postgresContainer.getPassword(),
+          database: postgresContainer.getDatabase(),
+          synchronize: true,
+          entities: [
+            Client2,
+            ChefDeFile,
+            Perimeter,
+            Habilitation,
+            Revision,
+            File,
+            Mandataire,
+          ],
+        }),
+        RevisionModule,
+        MailerModule,
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe());
+    await app.init();
+
+    mandataireRepository = app.get(getRepositoryToken(Mandataire));
+    clientRepository = app.get(getRepositoryToken(Client2));
+    chefDeFileRepository = app.get(getRepositoryToken(ChefDeFile));
+    habilitationRepository = app.get(getRepositoryToken(Habilitation));
+    revisionRepository = app.get(getRepositoryToken(Revision));
+    fileRepository = app.get(getRepositoryToken(File));
+    s3Service = app.get<S3Service>(S3Service);
+  });
+
+  afterAll(async () => {
+    await postgresClient.end();
+    await postgresContainer.stop();
+    await app.close();
+  });
+
+  afterEach(async () => {
+    await mandataireRepository.delete({});
+    await clientRepository.delete({});
+    await chefDeFileRepository.delete({});
+    await habilitationRepository.delete({});
+    await revisionRepository.delete({});
+    await fileRepository.delete({});
+    jest.restoreAllMocks();
+  });
+
+  function readFile(relativePath: string): Buffer {
+    return fs.readFileSync(join(__dirname, 'mock', relativePath));
+  }
+
+  /**
+   * Crée un client ANCT (admin BAL) sans chefDeFileId,
+   * ce qui permet de bypasser la vérification de périmètre dans la validation.
+   */
+  async function createAdminClient(): Promise<Client2> {
+    const mandataire = await mandataireRepository.save(
+      mandataireRepository.create({ nom: 'ANCT', email: 'anct@anct.fr' }),
+    );
+    const client = await clientRepository.save(
+      clientRepository.create({
+        nom: 'ANCT',
+        token: generateToken(),
+        authorizationStrategy: AuthorizationStrategyEnum.INTERNAL,
+        mandataireId: mandataire.id,
+      }),
+    );
+    process.env.ID_CLIENT_BAL_ADMIN = client.id;
+    return client;
+  }
+
+  async function createSourceClient(): Promise<Client2> {
+    const mandataire = await mandataireRepository.save(
+      mandataireRepository.create({
+        nom: 'mandataire',
+        email: 'mandataire@test.com',
+      }),
+    );
+    return clientRepository.save(
+      clientRepository.create({
+        nom: 'ANCT',
+        token: generateToken(),
+        authorizationStrategy: AuthorizationStrategyEnum.INTERNAL,
+        mandataireId: mandataire.id,
+      }),
+    );
+  }
+
+  async function createPublishedRevision(
+    clientId: string,
+    fileId: string,
+  ): Promise<Revision> {
+    const revision = await revisionRepository.save(
+      revisionRepository.create({
+        codeCommune: '31591',
+        clientId,
+        status: StatusRevisionEnum.PUBLISHED,
+        isCurrent: true,
+        isReady: null,
+        publishedAt: new Date(),
+      }),
+    );
+    await fileRepository.save(
+      fileRepository.create({ id: fileId, revisionId: revision.id }),
+    );
+    return revision;
+  }
+
+  /**
+   * Mock global.fetch pour les appels de formattingBAL (fetch API).
+   */
+  function mockFetchAssemblage() {
+    jest.spyOn(global, 'fetch').mockImplementation(async (url: RequestInfo) => {
+      const urlStr = url.toString();
+      if (urlStr.includes('/lookup/')) {
+        return {
+          ok: true,
+          json: async () => ({
+            typeComposition: 'assemblage',
+            withBanId: true,
+          }),
+        } as Response;
+      }
+      if (urlStr.includes('/api/district/cog/')) {
+        return {
+          ok: true,
+          json: async () => ({ response: [{ id: BAN_COMMUNE_ID }] }),
+        } as Response;
+      }
+      throw new Error(`fetch non mocké pour : ${urlStr}`);
+    });
+  }
+
+  function mockFetchLookupBALError() {
+    jest.spyOn(global, 'fetch').mockImplementation(async (url: RequestInfo) => {
+      const urlStr = url.toString();
+      if (urlStr.includes('/lookup/')) {
+        return {
+          ok: true,
+          json: async () => ({ typeComposition: 'bal', withBanId: false }),
+        } as Response;
+      }
+      throw new Error(`fetch non mocké pour : ${urlStr}`);
+    });
+  }
+
+  /**
+   * Mock https.get pour la route de téléchargement du CSV BAN de référence.
+   */
+  function mockHttpsDownload() {
+    jest.spyOn(https, 'get').mockImplementation((url: any, callback: any) => {
+      const mockStream = new Readable({ read() {} });
+      (mockStream as any).statusCode = 200;
+      (mockStream as any).headers = {};
+      process.nextTick(() => {
+        mockStream.push(banReferenceCsv);
+        mockStream.push(null);
+      });
+      callback(mockStream);
+      return { on: jest.fn() } as any;
+    });
+  }
+
+  /**
+   * Setup S3 mocks pour un test de succès.
+   * Retourne une fonction permettant de récupérer le fichier écrit.
+   */
+  function setupS3Mocks(
+    originalFileId: string,
+    inputCsv: Buffer,
+  ): { getWrittenFile: () => Buffer } {
+    let writtenFile: Buffer;
+    const newFileId = new ObjectId().toHexString();
+
+    jest
+      .spyOn(s3Service, 'writeFile')
+      .mockImplementation(async (buffer: Buffer) => {
+        writtenFile = buffer;
+        return newFileId;
+      });
+
+    jest
+      .spyOn(s3Service, 'getFile')
+      .mockImplementation(async (fileId: string) => {
+        if (fileId === originalFileId) {
+          return inputCsv;
+        }
+        return writtenFile;
+      });
+
+    return { getWrittenFile: () => writtenFile };
+  }
+
+  /**
+   * Parse un CSV BAL et retourne la première ligne de données.
+   */
+  function parseFirstRow(csvBuffer: Buffer): Record<string, string> {
+    const result = Papa.parse(csvBuffer.toString('utf-8'), {
+      header: true,
+      delimiter: ';',
+      skipEmptyLines: true,
+    });
+    return result.data[0] as Record<string, string>;
+  }
+
+  describe('POST /revisions/:revisionId/sync-ids-ban-publish', () => {
+    it('doit retourner 500 quand typeComposition=BAL et withBanId=false', async () => {
+      const adminClient = await createAdminClient();
+      const sourceClient = await createSourceClient();
+      const originalFileId = new ObjectId().toHexString();
+      const inputCsv = readFile('1.3-no-ids.csv');
+
+      const sourceRevision = await createPublishedRevision(
+        sourceClient.id,
+        originalFileId,
+      );
+
+      mockFetchLookupBALError();
+
+      jest.spyOn(s3Service, 'getFile').mockResolvedValue(inputCsv);
+
+      const { body } = await request(app.getHttpServer())
+        .post(`/revisions/${sourceRevision.id}/sync-ids-ban-publish`)
+        .set('Authorization', 'Bearer xxxx')
+        .expect(500);
+
+      expect(body.message).toContain(
+        "La commune n'a pas d'identifiants stables sur la BAN",
+      );
+
+      // Vérifier qu'aucune nouvelle révision n'a été créée pour le client admin
+      const adminRevisions = await revisionRepository.find({
+        where: { clientId: adminClient.id },
+      });
+      expect(adminRevisions).toHaveLength(0);
+    });
+
+    it('doit synchroniser les IDs BAN et publier avec une BAL 1.3 sans IDs', async () => {
+      await createAdminClient();
+      const sourceClient = await createSourceClient();
+      const originalFileId = new ObjectId().toHexString();
+      const inputCsv = readFile('1.3-no-ids.csv');
+
+      const sourceRevision = await createPublishedRevision(
+        sourceClient.id,
+        originalFileId,
+      );
+
+      mockFetchAssemblage();
+      mockHttpsDownload();
+      const { getWrittenFile } = setupS3Mocks(originalFileId, inputCsv);
+
+      const { body } = await request(app.getHttpServer())
+        .post(`/revisions/${sourceRevision.id}/sync-ids-ban-publish`)
+        .set('Authorization', 'Bearer xxxx')
+        .expect(200);
+
+      expect(body.status).toBe(StatusRevisionEnum.PUBLISHED);
+      expect(body.context.extras.sourceRevisionId).toBe(sourceRevision.id);
+
+      const row = parseFirstRow(getWrittenFile());
+      expect(row.id_ban_commune).toBe(BAN_COMMUNE_ID);
+      expect(row.id_ban_toponyme).toBe(BAN_TOPONYME_ID);
+      expect(row.id_ban_adresse).toBe(BAN_ADRESSE_ID);
+    });
+
+    it('doit synchroniser les IDs BAN et publier avec une BAL 1.3 avec uid_adresse', async () => {
+      await createAdminClient();
+      const sourceClient = await createSourceClient();
+      const originalFileId = new ObjectId().toHexString();
+      const inputCsv = readFile('1.3-with-ids.csv');
+
+      const sourceRevision = await createPublishedRevision(
+        sourceClient.id,
+        originalFileId,
+      );
+
+      mockFetchAssemblage();
+      mockHttpsDownload();
+      const { getWrittenFile } = setupS3Mocks(originalFileId, inputCsv);
+
+      const { body } = await request(app.getHttpServer())
+        .post(`/revisions/${sourceRevision.id}/sync-ids-ban-publish`)
+        .set('Authorization', 'Bearer xxxx')
+        .expect(200);
+
+      expect(body.status).toBe(StatusRevisionEnum.PUBLISHED);
+      expect(body.context.extras.sourceRevisionId).toBe(sourceRevision.id);
+
+      const row = parseFirstRow(getWrittenFile());
+      expect(row.id_ban_commune).toBe(BAN_COMMUNE_ID);
+      expect(row.id_ban_toponyme).toBe(BAN_TOPONYME_ID);
+      expect(row.id_ban_adresse).toBe(BAN_ADRESSE_ID);
+      // Les anciens IDs doivent avoir été remplacés
+      expect(row.id_ban_commune).not.toBe(OLD_TOPONYME_ID);
+      expect(row.id_ban_toponyme).not.toBe(OLD_TOPONYME_ID);
+      expect(row.id_ban_adresse).not.toBe(OLD_ADRESSE_ID);
+    });
+
+    it('doit synchroniser les IDs BAN et publier avec une BAL 1.4', async () => {
+      await createAdminClient();
+      const sourceClient = await createSourceClient();
+      const originalFileId = new ObjectId().toHexString();
+      const inputCsv = readFile('1.4-with-ids.csv');
+
+      const sourceRevision = await createPublishedRevision(
+        sourceClient.id,
+        originalFileId,
+      );
+
+      mockFetchAssemblage();
+      mockHttpsDownload();
+      const { getWrittenFile } = setupS3Mocks(originalFileId, inputCsv);
+
+      const { body } = await request(app.getHttpServer())
+        .post(`/revisions/${sourceRevision.id}/sync-ids-ban-publish`)
+        .set('Authorization', 'Bearer xxxx')
+        .expect(200);
+
+      expect(body.status).toBe(StatusRevisionEnum.PUBLISHED);
+      expect(body.context.extras.sourceRevisionId).toBe(sourceRevision.id);
+
+      const row = parseFirstRow(getWrittenFile());
+      expect(row.id_ban_commune).toBe(BAN_COMMUNE_ID);
+      expect(row.id_ban_toponyme).toBe(BAN_TOPONYME_ID);
+      expect(row.id_ban_adresse).toBe(BAN_ADRESSE_ID);
+      // Les anciens IDs doivent avoir été remplacés
+      expect(row.id_ban_commune).not.toBe(OLD_COMMUNE_ID);
+      expect(row.id_ban_toponyme).not.toBe(OLD_TOPONYME_ID);
+      expect(row.id_ban_adresse).not.toBe(OLD_ADRESSE_ID);
+    });
+
+    it('doit synchroniser les IDs BAN et publier avec une BAL 1.5', async () => {
+      await createAdminClient();
+      const sourceClient = await createSourceClient();
+      const originalFileId = new ObjectId().toHexString();
+      const inputCsv = readFile('1.5-with-ids.csv');
+
+      const sourceRevision = await createPublishedRevision(
+        sourceClient.id,
+        originalFileId,
+      );
+
+      mockFetchAssemblage();
+      mockHttpsDownload();
+      const { getWrittenFile } = setupS3Mocks(originalFileId, inputCsv);
+
+      const { body } = await request(app.getHttpServer())
+        .post(`/revisions/${sourceRevision.id}/sync-ids-ban-publish`)
+        .set('Authorization', 'Bearer xxxx')
+        .expect(200);
+
+      expect(body.status).toBe(StatusRevisionEnum.PUBLISHED);
+      expect(body.context.extras.sourceRevisionId).toBe(sourceRevision.id);
+
+      const row = parseFirstRow(getWrittenFile());
+      expect(row.id_ban_commune).toBe(BAN_COMMUNE_ID);
+      expect(row.id_ban_toponyme).toBe(BAN_TOPONYME_ID);
+      expect(row.id_ban_adresse).toBe(BAN_ADRESSE_ID);
+      // Les anciens IDs doivent avoir été remplacés
+      expect(row.id_ban_commune).not.toBe(OLD_COMMUNE_ID);
+      expect(row.id_ban_toponyme).not.toBe(OLD_TOPONYME_ID);
+      expect(row.id_ban_adresse).not.toBe(OLD_ADRESSE_ID);
+    });
+  });
+});

--- a/src/modules/revision/sync-and-publish.spec.ts
+++ b/src/modules/revision/sync-and-publish.spec.ts
@@ -206,7 +206,7 @@ describe('SYNC AND PUBLISH MODULE', () => {
   }
 
   /**
-   * Mock global.fetch pour les appels de formattingBAL (fetch API).
+   * Mock global.fetch pour les appels de formatterBAL (fetch API).
    */
   function mockFetchAssemblage() {
     jest.spyOn(global, 'fetch').mockImplementation(async (url: RequestInfo) => {

--- a/src/modules/revision/sync-and-publish.spec.ts
+++ b/src/modules/revision/sync-and-publish.spec.ts
@@ -303,7 +303,7 @@ describe('SYNC AND PUBLISH MODULE', () => {
   }
 
   describe('POST /revisions/:revisionId/sync-ids-ban-publish', () => {
-    it('doit retourner 500 quand typeComposition=BAL et withBanId=false', async () => {
+    it('doit retourner 500 quand la BAN ne repond pas', async () => {
       const adminClient = await createAdminClient();
       const sourceClient = await createSourceClient();
       const originalFileId = new ObjectId().toHexString();
@@ -324,7 +324,7 @@ describe('SYNC AND PUBLISH MODULE', () => {
         .expect(500);
 
       expect(body.message).toContain(
-        "La commune n'a pas d'identifiants stables sur la BAN",
+        'Impossible de fetch id_ban_commune de la BAN',
       );
 
       // Vérifier qu'aucune nouvelle révision n'a été créée pour le client admin
@@ -355,7 +355,7 @@ describe('SYNC AND PUBLISH MODULE', () => {
         .expect(200);
 
       expect(body.status).toBe(StatusRevisionEnum.PUBLISHED);
-      expect(body.context.extras.sourceRevisionId).toBe(sourceRevision.id);
+      expect(body.context.extras.syncRevisionId).toBe(sourceRevision.id);
 
       const row = parseFirstRow(getWrittenFile());
       expect(row.id_ban_commune).toBe(BAN_COMMUNE_ID);
@@ -384,7 +384,7 @@ describe('SYNC AND PUBLISH MODULE', () => {
         .expect(200);
 
       expect(body.status).toBe(StatusRevisionEnum.PUBLISHED);
-      expect(body.context.extras.sourceRevisionId).toBe(sourceRevision.id);
+      expect(body.context.extras.syncRevisionId).toBe(sourceRevision.id);
 
       const row = parseFirstRow(getWrittenFile());
       expect(row.id_ban_commune).toBe(BAN_COMMUNE_ID);
@@ -417,7 +417,7 @@ describe('SYNC AND PUBLISH MODULE', () => {
         .expect(200);
 
       expect(body.status).toBe(StatusRevisionEnum.PUBLISHED);
-      expect(body.context.extras.sourceRevisionId).toBe(sourceRevision.id);
+      expect(body.context.extras.syncRevisionId).toBe(sourceRevision.id);
 
       const row = parseFirstRow(getWrittenFile());
       expect(row.id_ban_commune).toBe(BAN_COMMUNE_ID);
@@ -450,7 +450,7 @@ describe('SYNC AND PUBLISH MODULE', () => {
         .expect(200);
 
       expect(body.status).toBe(StatusRevisionEnum.PUBLISHED);
-      expect(body.context.extras.sourceRevisionId).toBe(sourceRevision.id);
+      expect(body.context.extras.syncRevisionId).toBe(sourceRevision.id);
 
       const row = parseFirstRow(getWrittenFile());
       expect(row.id_ban_commune).toBe(BAN_COMMUNE_ID);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3862,6 +3862,11 @@ date-fns@^3.6.0:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-3.6.0.tgz#f20ca4fe94f8b754951b24240676e8618c0206bf"
   integrity sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==
 
+date-fns@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.1.0.tgz#64b3d83fff5aa80438f5b1a633c2e83b8a1c2d14"
+  integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
+
 dayjs@^1.11.9:
   version "1.11.13"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.13.tgz#92430b0139055c3ebb60150aa13e860a4b5a366c"
@@ -4729,6 +4734,17 @@ form-data@^4.0.0:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
+
+"formatting-bal@file:../formatting-bal":
+  version "0.1.0"
+  dependencies:
+    "@ban-team/adresses-util" "^0.9.0"
+    chardet "^1.4.0"
+    date-fns "^4.1.0"
+    file-type "^12.4.2"
+    iconv-lite "^0.6.3"
+    papaparse "^5.3.2"
+    yargs "^17.5.1"
 
 formidable@^3.5.1:
   version "3.5.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -995,6 +995,19 @@
     talisman "^1.1.4"
     written-number "^0.9.1"
 
+"@ban-team/formatter-bal@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@ban-team/formatter-bal/-/formatter-bal-0.1.1.tgz#1ebc83a99a0d21f6e72e6e9a73747f44f98a2a68"
+  integrity sha512-BsqvtBY5x1d0ypjdQJMpComa+oy5yYcc7HQNxXcQ75YUmmNbZl9gI2tjY7m6SSdFuy9p6/bzKjUnOjeWWM+w1w==
+  dependencies:
+    "@ban-team/adresses-util" "^0.9.0"
+    chardet "^1.4.0"
+    date-fns "^4.1.0"
+    file-type "^12.4.2"
+    iconv-lite "^0.6.3"
+    papaparse "^5.3.2"
+    yargs "^17.5.1"
+
 "@ban-team/shared-data@^1.4.3":
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/@ban-team/shared-data/-/shared-data-1.4.3.tgz#b8868d739dde7b6bb01af5a65221bbf0d81c7c25"
@@ -4734,17 +4747,6 @@ form-data@^4.0.0:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
-
-"formatting-bal@file:../formatting-bal":
-  version "0.1.0"
-  dependencies:
-    "@ban-team/adresses-util" "^0.9.0"
-    chardet "^1.4.0"
-    date-fns "^4.1.0"
-    file-type "^12.4.2"
-    iconv-lite "^0.6.3"
-    papaparse "^5.3.2"
-    yargs "^17.5.1"
 
 formidable@^3.5.1:
   version "3.5.1"


### PR DESCRIPTION
## CONTEXT

- Intégration de la route `revisions/:revisionId/sync-ids-ban-publish` qui synchronise la BAL de la révision avec les identifants BAN et ensuite publie une nouvelle révision