### PR TITLE
feat: download bal when revision not published

### DIFF
--- a/src/modules/revision/revision.controller.ts
+++ b/src/modules/revision/revision.controller.ts
@@ -1,7 +1,6 @@
 import {
   Controller,
   Get,
-  HttpException,
   HttpStatus,
   ParseArrayPipe,
   Query,

--- a/src/modules/revision/revision.controller.ts
+++ b/src/modules/revision/revision.controller.ts
@@ -203,12 +203,6 @@ export class RevisionController {
     operationId: 'DownloadFileRevision',
   })
   async downloadFile(@Req() req: CustomRequest, @Res() res: Response) {
-    if (req.revision.status !== StatusRevisionEnum.PUBLISHED) {
-      throw new HttpException(
-        "La révision n'est pas encore accessible car non publiée",
-        HttpStatus.FORBIDDEN,
-      );
-    }
     const data: Buffer = await this.fileService.findDataByRevision(
       req.revision.id,
     );


### PR DESCRIPTION
## CONTEXT

- Suppression de l'erreur qui empèche de download une BAL lorsque la révision n'est pas publiée