### PR TITLE
Revert Licence

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Agence nationale de la cohésion des territoires (ANCT) - Gouvernement Français
+Copyright (c) 2021 Base Adresse Nationale
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Actuellement l'api-depot a le copyright suivant suite à un changement la semaine dernière : Agence nationale de la cohésion des territoires (ANCT) - Gouvernement Français

Il faut changer ce copyright par "Base Adresse Nationale"