### PR TITLE
feat: add mail admin pro-connect

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -45,6 +45,7 @@ PC_SERVICE_URL=
 PC_FS_ID=
 PC_FS_SECRET=
 PC_FS_CALLBACK=http://localhost:4242/habilitations/proconnect/callback
+PC_EMAIL_ADMIN=
 
 # -------------------------------------
 # ------ Paramètre serveur smpt -------

--- a/src/modules/habilitation/habilitation.service.ts
+++ b/src/modules/habilitation/habilitation.service.ts
@@ -288,9 +288,8 @@ export class HabilitationService {
     const habilitation = await this.findOneOrFail(habilitationId);
 
     if (habilitation.status === StatusHabilitationEnum.PENDING) {
-      const proConnectMailAdmin = this.configService
-        .get('PC_EMAIL_ADMIN')
-        .split(',');
+      const proConnectMailAdmin =
+        this.configService.get('PC_EMAIL_ADMIN')?.split(',') || [];
 
       const siretBelongToCommune: boolean =
         await this.apiAnnuaireService.siretBelongToCommune(

--- a/src/modules/habilitation/habilitation.service.ts
+++ b/src/modules/habilitation/habilitation.service.ts
@@ -288,13 +288,17 @@ export class HabilitationService {
     const habilitation = await this.findOneOrFail(habilitationId);
 
     if (habilitation.status === StatusHabilitationEnum.PENDING) {
+      const proConnectMailAdmin = this.configService
+        .get('PC_EMAIL_ADMIN')
+        .split(',');
+
       const siretBelongToCommune: boolean =
         await this.apiAnnuaireService.siretBelongToCommune(
           user.siret,
           habilitation.codeCommune,
         );
 
-      if (siretBelongToCommune) {
+      if (siretBelongToCommune || proConnectMailAdmin.includes(user.email)) {
         await this.acceptHabilitation(habilitation.id, {
           strategy: {
             type: TypeStrategyEnum.PROCONNECT,

--- a/src/modules/habilitation/pro_connect/pro_connect.strategy.ts
+++ b/src/modules/habilitation/pro_connect/pro_connect.strategy.ts
@@ -29,7 +29,7 @@ export class ProConnectStrategy extends PassportStrategy(
         callbackURL:
           configService.get('API_DEPOT_URL') +
           '/habilitations/proconnect/callback',
-        scope: ['openid', 'siret'],
+        scope: ['openid', 'siret', 'email'],
         passReqToCallback: true,
       },
       (req, accessToken, refreshToken, params, profile, done) => {

--- a/src/modules/habilitation/pro_connect/pro_connect_user.type.ts
+++ b/src/modules/habilitation/pro_connect/pro_connect_user.type.ts
@@ -2,4 +2,5 @@ export type ProConnectUser = {
   siret: string;
   given_name: string;
   usual_name: string;
+  email: string;
 };


### PR DESCRIPTION
## CONTEXT

Ajout d'email admin dans une variable d'env pour que l'équipe puisse s'identifier sur n'import quelle commune avec pro-connect
